### PR TITLE
feat(pipeline): resilience + caching + Batches API (cost-optimized daily batch)

### DIFF
--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -83,6 +83,10 @@ jobs:
           echo "list=$DATES" >> "$GITHUB_OUTPUT"
 
       # ----- Summarize (auto-resume per date) -----
+      # --batch routes the per-thread summary calls through the Message
+      # Batches API for a 50% input/output token discount, stackable with
+      # the prompt-caching prefix. Grouping and outcome extraction remain
+      # synchronous (one small call per meeting; not worth batching).
       - name: Summarize new content with Claude API
         if: steps.dates.outputs.list != ''
         env:
@@ -92,7 +96,7 @@ jobs:
           set -e
           for d in $DATES_LIST; do
             echo "::group::Summarize $d"
-            python scripts/summarize.py --date "$d"
+            python scripts/summarize.py --date "$d" --batch
             echo "::endgroup::"
           done
 

--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -2,14 +2,16 @@ name: Daily Batch
 
 on:
   schedule:
-    # Run at 6:00 AM JST (21:00 UTC previous day)
-    # NDL transcripts are typically published a few days after proceedings
+    # Run at 6:00 AM JST (21:00 UTC previous day).
+    # NDL transcripts are typically published days or weeks after a session,
+    # so the batch re-fetches a sliding window each run.
     - cron: "0 21 * * *"
   workflow_dispatch:
     inputs:
-      date:
-        description: "Date to process (YYYY-MM-DD), defaults to yesterday"
+      lookback_days:
+        description: "How many past days to (re-)fetch. Default: 30"
         required: false
+        default: "30"
 
 permissions:
   contents: write
@@ -19,6 +21,10 @@ jobs:
     name: Fetch & Summarize
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      # Route untrusted input through env so it never lands in a run: string
+      # as a literal expression interpolation.
+      LOOKBACK_DAYS: ${{ inputs.lookback_days || '30' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,73 +43,73 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      - name: Determine date
-        id: date
+      - name: Validate lookback window
+        # Defense-in-depth: the input is admin-only and is also routed through
+        # env, but we still pin it to a small integer before any shell use.
         run: |
-          if [ -n "${{ github.event.inputs.date }}" ]; then
-            echo "target=${{ github.event.inputs.date }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "target=$(date -u -d 'yesterday' +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          case "$LOOKBACK_DAYS" in
+            ''|*[!0-9]*) echo "Invalid LOOKBACK_DAYS: $LOOKBACK_DAYS"; exit 1 ;;
+          esac
+          if [ "$LOOKBACK_DAYS" -gt 365 ]; then
+            echo "LOOKBACK_DAYS too large: $LOOKBACK_DAYS"; exit 1
           fi
 
       # ----- Source: NDL Diet Records -----
-      - name: Fetch from NDL API
-        run: python scripts/fetch_ndl.py --date-from ${{ steps.date.outputs.target }} --date-until ${{ steps.date.outputs.target }}
-
-      - name: Check NDL speeches
-        id: check_ndl
-        run: |
-          FILE="data/raw/ndl-${{ steps.date.outputs.target }}.json"
-          # Fallback to legacy filename
-          [ ! -f "$FILE" ] && FILE="data/raw/${{ steps.date.outputs.target }}.json"
-          if [ -f "$FILE" ]; then
-            COUNT=$(python3 -c "import json; d=json.load(open('$FILE')); print(d['metadata']['totalSpeeches'])")
-            echo "speeches=$COUNT" >> "$GITHUB_OUTPUT"
-            echo "NDL: Found $COUNT speeches"
-          else
-            echo "speeches=0" >> "$GITHUB_OUTPUT"
-            echo "NDL: No data file found"
-          fi
+      - name: Fetch from NDL API (lookback window)
+        run: python scripts/fetch_ndl.py --lookback-days "$LOOKBACK_DAYS"
 
       # ----- Source: Kantei Press Conferences -----
-      - name: Fetch from Kantei
-        id: check_kantei
+      - name: Fetch from Kantei (lookback window)
         continue-on-error: true
-        run: |
-          python scripts/fetch_kantei.py --date-from ${{ steps.date.outputs.target }} --date-until ${{ steps.date.outputs.target }}
-          FILE="data/raw/kantei-${{ steps.date.outputs.target }}.json"
-          if [ -f "$FILE" ]; then
-            COUNT=$(python3 -c "import json; d=json.load(open('$FILE')); print(d['metadata']['totalSpeeches'])")
-            echo "speeches=$COUNT" >> "$GITHUB_OUTPUT"
-            echo "Kantei: Found $COUNT speeches"
-          else
-            echo "speeches=0" >> "$GITHUB_OUTPUT"
-            echo "Kantei: No press conferences found"
-          fi
+        run: python scripts/fetch_kantei.py --lookback-days "$LOOKBACK_DAYS"
 
       # ----- Source: Council (審議会) Meeting Minutes -----
-      - name: Fetch from Council
-        id: check_council
+      - name: Fetch from Council (lookback window)
         continue-on-error: true
         run: |
-          TOTAL=0
           for COUNCIL in kisei nichiiki kankeijinkou suishin chiikiseikatsu chihousousei digital_denen kyojushien; do
-            python scripts/fetch_council.py --council "$COUNCIL" --date-from ${{ steps.date.outputs.target }} --date-until ${{ steps.date.outputs.target }} || true
+            python scripts/fetch_council.py --council "$COUNCIL" --lookback-days "$LOOKBACK_DAYS" || true
           done
-          for FILE in data/raw/council-*-${{ steps.date.outputs.target }}.json data/raw/council-${{ steps.date.outputs.target }}.json; do
-            [ -f "$FILE" ] || continue
-            COUNT=$(python3 -c "import json; d=json.load(open('$FILE')); print(d['metadata']['totalSpeeches'])")
-            TOTAL=$((TOTAL + COUNT))
-          done
-          echo "speeches=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "Council: Found $TOTAL speeches"
 
-      # ----- Summarize -----
-      - name: Summarize with Claude API
-        if: steps.check_ndl.outputs.speeches != '0' || steps.check_kantei.outputs.speeches != '0' || steps.check_council.outputs.speeches != '0'
+      # ----- Determine which dates have raw data -----
+      - name: Detect dates with raw data
+        id: dates
+        run: |
+          DATES=$(ls data/raw/ 2>/dev/null \
+            | grep -E '^(ndl|kantei|council-[a-z_]+)-[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$' \
+            | sed -E 's/^(ndl|kantei|council-[a-z_]+)-([0-9]{4}-[0-9]{2}-[0-9]{2})\.json$/\2/' \
+            | sort -u | tr '\n' ' ')
+          echo "Found raw data for dates: $DATES"
+          echo "list=$DATES" >> "$GITHUB_OUTPUT"
+
+      # ----- Summarize (auto-resume per date) -----
+      - name: Summarize new content with Claude API
+        if: steps.dates.outputs.list != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: python scripts/summarize.py --date ${{ steps.date.outputs.target }}
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+        run: |
+          set -e
+          for d in $DATES_LIST; do
+            echo "::group::Summarize $d"
+            python scripts/summarize.py --date "$d"
+            echo "::endgroup::"
+          done
+
+      # ----- Enrich threads with news articles (Bing News RSS) -----
+      - name: Enrich threads with news
+        if: steps.dates.outputs.list != ''
+        continue-on-error: true
+        env:
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+        run: |
+          for d in $DATES_LIST; do
+            if [ -f "data/threads/$d.json" ]; then
+              echo "::group::Enrich $d"
+              python scripts/enrich-news.py --date "$d" || true
+              echo "::endgroup::"
+            fi
+          done
 
       # ----- Post-processing -----
       - name: Validate and generate
@@ -112,33 +118,100 @@ jobs:
           node scripts/generate-feeds.js
           node scripts/generate-sitemap.mjs
 
+      # ----- Compute "new threads added" metrics for monitoring -----
+      - name: Compute new-thread metrics
+        id: metrics
+        env:
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+        run: |
+          TOTAL_NEW=0
+          NEW_DATES=""
+          for d in $DATES_LIST; do
+            FILE="data/threads/$d.json"
+            [ -f "$FILE" ] || continue
+            COUNT=$(python3 -c "import json; print(len(json.load(open('$FILE'))))")
+            BEFORE=$(git show HEAD:"$FILE" 2>/dev/null \
+              | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null \
+              || echo 0)
+            DELTA=$((COUNT - BEFORE))
+            if [ "$DELTA" -gt 0 ]; then
+              TOTAL_NEW=$((TOTAL_NEW + DELTA))
+              NEW_DATES="$NEW_DATES $d(+$DELTA)"
+            fi
+          done
+          echo "new_threads=$TOTAL_NEW" >> "$GITHUB_OUTPUT"
+          echo "new_dates=$NEW_DATES" >> "$GITHUB_OUTPUT"
+          echo "Total new threads this run: $TOTAL_NEW"
+
       - name: Commit and push data
+        id: commit
+        env:
+          NEW_THREADS: ${{ steps.metrics.outputs.new_threads }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/threads/ data/members.json data/status.json public/sitemap.xml public/feed.xml
+          # public/sitemap*.xml covers sitemap.xml, sitemap-*.xml and sitemap_index.xml
+          # — all variants emitted by generate-sitemap.mjs.
+          git add data/threads/ data/members.json data/status.json \
+            public/sitemap.xml public/sitemap-*.xml public/sitemap_index.xml \
+            public/feed.xml
           if git diff --cached --quiet; then
             echo "No changes to commit"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "data: update ${{ steps.date.outputs.target }}"
+            DATE_TAG=$(date -u +%Y-%m-%d)
+            git commit -m "data: daily-batch run ${DATE_TAG} (+${NEW_THREADS} threads)"
             git push
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Notify IndexNow
-        if: steps.check_ndl.outputs.speeches != '0' || steps.check_kantei.outputs.speeches != '0' || steps.check_council.outputs.speeches != '0'
+        if: steps.metrics.outputs.new_threads != '0'
         continue-on-error: true
-        run: node scripts/notify-indexnow.mjs --date ${{ steps.date.outputs.target }}
+        env:
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+        run: |
+          for d in $DATES_LIST; do
+            if [ -f "data/threads/$d.json" ]; then
+              node scripts/notify-indexnow.mjs --date "$d" || true
+            fi
+          done
+
+      # ----- Surface "stalled pipeline" alerts in the workflow summary -----
+      # Several consecutive zero-thread runs likely indicate a real pipeline
+      # failure (NDL schema change, auth issue), not just a quiet Diet week.
+      - name: Detect stalled pipeline
+        id: stall
+        run: |
+          STALLED=0
+          while read -r line; do
+            if echo "$line" | grep -q '(+0 threads)'; then
+              STALLED=$((STALLED + 1))
+            else
+              break
+            fi
+          done < <(git log --pretty=format:"%s" -n 10)
+          echo "consecutive_zero_runs=$STALLED" >> "$GITHUB_OUTPUT"
+          if [ "$STALLED" -ge 7 ]; then
+            echo "::warning::Pipeline has produced 0 new threads for $STALLED consecutive runs — investigate fetchers"
+          fi
 
       - name: Summary
+        env:
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+          NEW_THREADS: ${{ steps.metrics.outputs.new_threads }}
+          NEW_DATES: ${{ steps.metrics.outputs.new_dates }}
+          COMMITTED: ${{ steps.commit.outputs.committed }}
+          STALLED: ${{ steps.stall.outputs.consecutive_zero_runs }}
         run: |
-          echo "## Daily Batch Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Date**: ${{ steps.date.outputs.target }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **NDL speeches**: ${{ steps.check_ndl.outputs.speeches }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Kantei speeches**: ${{ steps.check_kantei.outputs.speeches || '0' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Council speeches**: ${{ steps.check_council.outputs.speeches || '0' }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f "data/threads/${{ steps.date.outputs.target }}.json" ]; then
-            THREADS=$(python3 -c "import json; print(len(json.load(open('data/threads/${{ steps.date.outputs.target }}.json'))))")
-            echo "- **Threads generated**: $THREADS" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "- **Threads generated**: 0 (no data or weekend)" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          {
+            echo "## Daily Batch Summary"
+            echo "- **Lookback window**: ${LOOKBACK_DAYS} days"
+            echo "- **Dates with raw data**: ${DATES_LIST:-(none)}"
+            echo "- **New threads this run**: ${NEW_THREADS}"
+            if [ -n "${NEW_DATES}" ]; then
+              echo "- **Per-date breakdown**:${NEW_DATES}"
+            fi
+            echo "- **Committed**: ${COMMITTED}"
+            echo "- **Consecutive zero-thread runs**: ${STALLED}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/fetch_council.py
+++ b/scripts/fetch_council.py
@@ -28,12 +28,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Fetch council meeting minutes from government websites"
     )
     parser.add_argument(
-        "--date-from", default=yesterday,
-        help="Start date YYYY-MM-DD (default: yesterday)",
+        "--date-from", default=None,
+        help="Start date YYYY-MM-DD (default: yesterday, ignored when --lookback-days is set)",
     )
     parser.add_argument(
         "--date-until", default=None,
         help="End date YYYY-MM-DD (default: same as --date-from)",
+    )
+    parser.add_argument(
+        "--lookback-days", type=int, default=None,
+        help="Fetch the last N days up to today. Overrides --date-from/--date-until. "
+             "Recommended for daily batches because council minutes (PDFs) are "
+             "often uploaded weeks after the meeting.",
     )
     parser.add_argument(
         "--council", default="kisei",
@@ -48,8 +54,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     args = parser.parse_args(argv)
-    if args.date_until is None:
-        args.date_until = args.date_from
+
+    if args.lookback_days is not None:
+        if args.lookback_days < 0:
+            parser.error("--lookback-days must be >= 0")
+        today = date.today()
+        args.date_from = (today - timedelta(days=args.lookback_days)).isoformat()
+        args.date_until = today.isoformat()
+    else:
+        if args.date_from is None:
+            args.date_from = yesterday
+        if args.date_until is None:
+            args.date_until = args.date_from
+
     return args
 
 
@@ -75,14 +92,21 @@ def main(argv: list[str] | None = None) -> None:
         verbose=args.verbose,
     )
 
-    if result.meetings:
+    if not result.meetings:
+        log.info("No meetings with minutes found in date range")
+        return
+
+    if args.date_from != args.date_until:
+        written = adapter.write_output_by_meeting_date(result, output_dir=args.output_dir)
+        for meeting_date, filepath, count in written:
+            log.info("  %s: %d speeches → %s", meeting_date, count, filepath)
+        log.info("Wrote %d per-date raw files", len(written))
+    else:
         filepath = adapter.write_output(result, output_dir=args.output_dir)
         log.info(
             "Wrote %d meeting(s) (%d speeches) → %s",
             len(result.meetings), result.total_speeches, filepath,
         )
-    else:
-        log.info("No meetings with minutes found in date range")
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_kantei.py
+++ b/scripts/fetch_kantei.py
@@ -27,12 +27,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Fetch PM press conference transcripts from kantei.go.jp"
     )
     parser.add_argument(
-        "--date-from", default=yesterday,
-        help="Start date YYYY-MM-DD (default: yesterday)",
+        "--date-from", default=None,
+        help="Start date YYYY-MM-DD (default: yesterday, ignored when --lookback-days is set)",
     )
     parser.add_argument(
         "--date-until", default=None,
         help="End date YYYY-MM-DD (default: same as --date-from)",
+    )
+    parser.add_argument(
+        "--lookback-days", type=int, default=None,
+        help="Fetch the last N days up to today. Overrides --date-from/--date-until.",
     )
     parser.add_argument(
         "--cabinet", default=DEFAULT_CABINET,
@@ -46,8 +50,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     args = parser.parse_args(argv)
-    if args.date_until is None:
-        args.date_until = args.date_from
+
+    if args.lookback_days is not None:
+        if args.lookback_days < 0:
+            parser.error("--lookback-days must be >= 0")
+        today = date.today()
+        args.date_from = (today - timedelta(days=args.lookback_days)).isoformat()
+        args.date_until = today.isoformat()
+    else:
+        if args.date_from is None:
+            args.date_from = yesterday
+        if args.date_until is None:
+            args.date_until = args.date_from
+
     return args
 
 
@@ -69,12 +84,19 @@ def main(argv: list[str] | None = None) -> None:
         verbose=args.verbose,
     )
 
-    if result.meetings:
+    if not result.meetings:
+        log.info("No press conferences found in date range")
+        return
+
+    if args.date_from != args.date_until:
+        written = adapter.write_output_by_meeting_date(result, output_dir=args.output_dir)
+        for meeting_date, filepath, count in written:
+            log.info("  %s: %d speeches → %s", meeting_date, count, filepath)
+        log.info("Wrote %d per-date raw files", len(written))
+    else:
         filepath = adapter.write_output(result, output_dir=args.output_dir)
         log.info("Wrote %d conference(s) (%d speeches) → %s",
                  len(result.meetings), result.total_speeches, filepath)
-    else:
-        log.info("No press conferences found in date range")
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_ndl.py
+++ b/scripts/fetch_ndl.py
@@ -7,6 +7,13 @@ AI summarization.  Uses the NDL source adapter from scripts/sources/.
 Usage:
     python scripts/fetch_ndl.py --date-from 2025-03-14
     python scripts/fetch_ndl.py --date-from 2025-03-14 --date-until 2025-03-15 --verbose
+    python scripts/fetch_ndl.py --lookback-days 30          # last 30 days, split per meeting date
+
+NDL transcripts are typically published days or weeks after the actual
+proceeding.  Use ``--lookback-days N`` from the daily batch to re-fetch
+the last N days each run so retroactively published meetings are picked up.
+Multi-day fetches are automatically split into single-date raw files so the
+downstream summarizer can consume them without changes.
 """
 
 from __future__ import annotations
@@ -31,12 +38,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Fetch Diet speech records from the NDL API"
     )
     parser.add_argument(
-        "--date-from", default=yesterday,
-        help="Start date YYYY-MM-DD (default: yesterday)",
+        "--date-from", default=None,
+        help="Start date YYYY-MM-DD (default: yesterday, ignored when --lookback-days is set)",
     )
     parser.add_argument(
         "--date-until", default=None,
         help="End date YYYY-MM-DD (default: same as --date-from)",
+    )
+    parser.add_argument(
+        "--lookback-days", type=int, default=None,
+        help="Fetch the last N days up to today. Overrides --date-from/--date-until. "
+             "Recommended for daily batches because NDL publishes transcripts with a "
+             "multi-day lag.",
     )
     parser.add_argument("--house", default=None, help="衆議院 or 参議院")
     parser.add_argument("--meeting", default=None, help="Committee name filter")
@@ -52,8 +65,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     args = parser.parse_args(argv)
-    if args.date_until is None:
-        args.date_until = args.date_from
+
+    if args.lookback_days is not None:
+        if args.lookback_days < 0:
+            parser.error("--lookback-days must be >= 0")
+        today = date.today()
+        args.date_from = (today - timedelta(days=args.lookback_days)).isoformat()
+        args.date_until = today.isoformat()
+    else:
+        if args.date_from is None:
+            args.date_from = yesterday
+        if args.date_until is None:
+            args.date_until = args.date_from
+
     return args
 
 
@@ -79,8 +103,20 @@ def main(argv: list[str] | None = None) -> None:
 
     log.info("Received %d speeches in %d meetings", result.total_speeches, len(result.meetings))
 
-    filepath = adapter.write_output(result, output_dir=args.output_dir)
-    log.info("Wrote → %s", filepath)
+    # Split multi-day windows by meeting date so summarize.py can consume the
+    # single-date filename convention. Single-day fetches keep the original
+    # behavior for backward compatibility.
+    if args.date_from != args.date_until:
+        written = adapter.write_output_by_meeting_date(result, output_dir=args.output_dir)
+        if not written:
+            log.info("No meetings found in window %s → %s", args.date_from, args.date_until)
+            return
+        for meeting_date, filepath, count in written:
+            log.info("  %s: %d speeches → %s", meeting_date, count, filepath)
+        log.info("Wrote %d per-date raw files", len(written))
+    else:
+        filepath = adapter.write_output(result, output_dir=args.output_dir)
+        log.info("Wrote → %s", filepath)
 
 
 if __name__ == "__main__":

--- a/scripts/pipeline/grouper.py
+++ b/scripts/pipeline/grouper.py
@@ -7,7 +7,13 @@ import logging
 import re
 from typing import Dict, List, Optional
 
-from .prompts import GROUPING_SYSTEM, GROUPING_PROMPT, OUTCOME_SYSTEM, OUTCOME_PROMPT
+from .prompts import (
+    GROUPING_SYSTEM,
+    GROUPING_INSTRUCTIONS,
+    GROUPING_INPUT_TEMPLATE,
+    OUTCOME_SYSTEM,
+    OUTCOME_PROMPT,
+)
 
 log = logging.getLogger("pipeline.grouper")
 
@@ -100,12 +106,27 @@ def group_meeting(
 
     formatted = "\n\n".join(_format_speech_for_grouping(s) for s in substantive)
 
-    prompt = GROUPING_PROMPT.format(
+    user_input = GROUPING_INPUT_TEMPLATE.format(
         house=meeting.get("house", ""),
         meeting=meeting.get("meeting", ""),
         date=meeting.get("date", ""),
         speeches=formatted,
     )
+
+    # Static rules + format spec are sent as a separate content block with
+    # cache_control so subsequent calls within ~5min only pay ~10% of input
+    # tokens for this prefix. See pipeline/prompts.py for details.
+    messages = [{
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": GROUPING_INSTRUCTIONS,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": user_input},
+        ],
+    }]
 
     log.info(
         "Grouping %s (%d substantive speeches)",
@@ -116,7 +137,7 @@ def group_meeting(
         model=model,
         max_tokens=8192,
         system=GROUPING_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
+        messages=messages,
     )
 
     # Check if response was truncated
@@ -127,14 +148,27 @@ def group_meeting(
             model=model,
             max_tokens=16384,
             system=GROUPING_SYSTEM,
-            messages=[{"role": "user", "content": prompt}],
+            messages=messages,
         )
+
+    _log_cache_usage(response, "grouping")
 
     result = _parse_json_response(response.content[0].text)
     threads = result.get("threads", [])
 
     log.info("Found %d threads in %s", len(threads), meeting.get("meetingId", "?"))
     return threads
+
+
+def _log_cache_usage(response, phase: str) -> None:
+    """Log prompt cache hit/write stats so we can verify caching works."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    read = getattr(usage, "cache_read_input_tokens", 0) or 0
+    write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    if read or write:
+        log.info("  cache[%s]: read=%d write=%d", phase, read, write)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/pipeline/prompts.py
+++ b/scripts/pipeline/prompts.py
@@ -2,6 +2,19 @@
 
 All prompts are centralized here for transparency and auditability.
 These prompts are open-sourced as part of GIKAI's political neutrality guarantee.
+
+Each prompt is split into two parts:
+    *_INSTRUCTIONS — the static rules / examples / output format. This block
+                      is identical across every call and is marked with
+                      ``cache_control: {"type": "ephemeral"}`` by the caller
+                      so subsequent calls within the 5-minute window only pay
+                      for the variable input. The literal rule text is
+                      unchanged from the original combined prompt; only the
+                      block ordering changed.
+    *_INPUT_TEMPLATE — the per-call variable portion (meeting metadata and
+                       speeches) that is filled in with ``.format(...)``.
+
+The system prompt is also unchanged.
 """
 
 # ---------------------------------------------------------------------------
@@ -12,11 +25,8 @@ GROUPING_SYSTEM = """\
 あなたは国会の議事録を構造化するアシスタントです。
 政治的に中立な立場で、与党・野党を区別せず同じ基準で処理してください。"""
 
-GROUPING_PROMPT = """\
-以下は国会の{house}{meeting}（{date}）の発言一覧です。
-各発言の冒頭部分と発言者情報を示します。
-
-これらの発言をテーマ（議題・話題）単位でグルーピングしてください。
+GROUPING_INSTRUCTIONS = """\
+国会の発言一覧をテーマ（議題・話題）単位でグルーピングしてください。
 
 ## ルール
 - 委員長の手続き発言（開会宣言、議案朗読、採決宣告など）はどのテーマにも含めない
@@ -34,14 +44,11 @@ GROUPING_PROMPT = """\
   例: 「AIの開発・利用に関するリスク分類と規制の枠組みを定める法案。2024年に閣議決定。」
 - legislationName: 議論の対象となっている法案・法律名があれば正式名称（なければnull）
 
-## 発言一覧
-{speeches}
-
 ## 出力（JSONのみ、他のテキストは不要）
 ```json
-{{
+{
   "threads": [
-    {{
+    {
       "topic": "テーマ名",
       "topicTag": "短縮タグ",
       "topicColor": "#hex",
@@ -49,10 +56,17 @@ GROUPING_PROMPT = """\
       "contextDescription": "このテーマの背景説明（80字以内）",
       "legislationName": "正式な法案・法律名（あれば）",
       "speechOrders": [4, 5, 6, 7]
-    }}
+    }
   ]
-}}
+}
 ```"""
+
+GROUPING_INPUT_TEMPLATE = """\
+以下は国会の{house}{meeting}（{date}）の発言一覧です。
+各発言の冒頭部分と発言者情報を示します。
+
+## 発言一覧
+{speeches}"""
 
 
 # ---------------------------------------------------------------------------
@@ -63,9 +77,8 @@ SUMMARY_SYSTEM = """\
 あなたは国会の議事録を要約するアシスタントです。
 政治的に中立な立場で、与党・野党を区別せず同じ基準で処理してください。"""
 
-SUMMARY_PROMPT = """\
-以下は{house}{meeting}の「{topic}」に関する発言です。
-各発言について、要約・分類・キーワード抽出を行ってください。
+SUMMARY_INSTRUCTIONS = """\
+発言について、要約・分類・キーワード抽出を行ってください。
 
 ## 要約の文体ルール（最重要）
 要約は発言内容そのものを簡潔に表現する。報告文体は絶対に使わない。
@@ -107,9 +120,6 @@ SUMMARY_PROMPT = """\
 
 同じ概念を指す表記が複数あり得る場合は、常に最も一般的で短い形を選ぶ。
 
-## 発言一覧
-{speeches}
-
 ## コミットメント抽出
 答弁の中で大臣・政府委員が具体的に約束・表明したことを抽出する。
 例: 「採決前に影響試算を提出する」「次の国会で法案を出す」「検討会を設置する」
@@ -117,28 +127,36 @@ SUMMARY_PROMPT = """\
 
 ## 出力（JSONのみ、他のテキストは不要）
 ```json
-{{
+{
   "speeches": [
-    {{
+    {
       "speechOrder": 4,
       "tension": "追及",
       "keywords": ["キーワード1", "キーワード2", "キーワード3"],
       "quote": "原文から最も重要な一文をそのまま抜粋（改変不可）",
-      "summaries": {{
+      "summaries": {
         "easy": "...(60-80字)",
         "teen": "...(80-100字)",
         "adult": "...(60-80字)"
-      }}
-    }}
+      }
+    }
   ],
   "commitments": ["具体的な約束1", "具体的な約束2"]
-}}
+}
 ```"""
+
+SUMMARY_INPUT_TEMPLATE = """\
+以下は{house}{meeting}の「{topic}」に関する発言です。
+
+## 発言一覧
+{speeches}"""
 
 
 # ---------------------------------------------------------------------------
 # Phase D: Meeting-level outcome extraction (votes, resolutions)
 # ---------------------------------------------------------------------------
+# This prompt is short enough that caching is not worthwhile (cached prefix
+# must reach 1,024 tokens). Kept as a single combined template.
 
 OUTCOME_SYSTEM = """\
 あなたは国会の議事録から採決結果と附帯決議を抽出するアシスタントです。"""

--- a/scripts/pipeline/summarizer.py
+++ b/scripts/pipeline/summarizer.py
@@ -1,11 +1,18 @@
-"""Per-thread speech summarization via Claude API."""
+"""Per-thread speech summarization via Claude API.
+
+Provides both a synchronous path (``summarize_thread``) and an asynchronous
+batched path (``build_summary_request`` + ``submit_summary_batch`` + polling
+helpers). The batch path uses Anthropic's Message Batches API for a 50%
+cost discount on input + output tokens, stackable with prompt caching.
+"""
 
 from __future__ import annotations
 
 import json
 import logging
 import re
-from typing import Dict, List, Optional
+import time
+from typing import Any, Dict, List, Optional
 
 from .prompts import SUMMARY_SYSTEM, SUMMARY_INSTRUCTIONS, SUMMARY_INPUT_TEMPLATE
 
@@ -124,3 +131,153 @@ def _log_cache_usage(response) -> None:
     write = getattr(usage, "cache_creation_input_tokens", 0) or 0
     if read or write:
         log.info("  cache[summary]: read=%d write=%d", read, write)
+
+
+# ---------------------------------------------------------------------------
+# Batch API: build, submit, poll, fetch
+# ---------------------------------------------------------------------------
+
+def build_summary_request(
+    meeting: dict,
+    thread_info: dict,
+    speeches: List[dict],
+    custom_id: str,
+    model: str = "claude-sonnet-4-20250514",
+) -> dict:
+    """Build a single Message Batches API request for one thread's summary.
+
+    Returns the request dict shape expected by client.messages.batches.create().
+    """
+    formatted = "\n\n---\n\n".join(_format_speech_for_summary(s) for s in speeches)
+
+    user_input = SUMMARY_INPUT_TEMPLATE.format(
+        house=meeting.get("house", ""),
+        meeting=meeting.get("meeting", ""),
+        topic=thread_info.get("topic", ""),
+        speeches=formatted,
+    )
+
+    return {
+        "custom_id": custom_id,
+        "params": {
+            "model": model,
+            "max_tokens": 8192,
+            "system": SUMMARY_SYSTEM,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": SUMMARY_INSTRUCTIONS,
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"type": "text", "text": user_input},
+                ],
+            }],
+        },
+    }
+
+
+def submit_summary_batch(client, requests: List[dict]) -> str:
+    """Submit a batch of summary requests. Returns the batch ID."""
+    log.info("Submitting batch with %d summary requests", len(requests))
+    batch = client.messages.batches.create(requests=requests)
+    log.info("Batch %s created (status=%s)", batch.id, batch.processing_status)
+    return batch.id
+
+
+def poll_summary_batch(
+    client,
+    batch_id: str,
+    timeout_seconds: int = 5400,
+    poll_interval_seconds: int = 30,
+):
+    """Poll a batch until it ends or the timeout elapses.
+
+    Returns the final batch object. Raises TimeoutError on timeout.
+    """
+    start = time.time()
+    last_logged = 0.0
+
+    while True:
+        batch = client.messages.batches.retrieve(batch_id)
+        elapsed = int(time.time() - start)
+
+        if batch.processing_status == "ended":
+            log.info(
+                "Batch %s ended after %ds (counts=%s)",
+                batch_id, elapsed, batch.request_counts,
+            )
+            return batch
+
+        # Log every ~2 minutes to avoid spamming CI logs
+        if elapsed - last_logged >= 120:
+            log.info(
+                "Batch %s status=%s elapsed=%ds",
+                batch_id, batch.processing_status, elapsed,
+            )
+            last_logged = elapsed
+
+        if elapsed >= timeout_seconds:
+            raise TimeoutError(
+                f"Batch {batch_id} did not end within {timeout_seconds}s "
+                f"(last status: {batch.processing_status})"
+            )
+        time.sleep(poll_interval_seconds)
+
+
+def fetch_summary_results(client, batch_id: str) -> Dict[str, Optional[dict]]:
+    """Fetch and parse all results from a completed batch.
+
+    Returns a dict mapping custom_id -> parsed result dict (or None if the
+    request failed or its output could not be parsed).
+    """
+    results: Dict[str, Optional[dict]] = {}
+    succeeded = 0
+    failed = 0
+
+    for entry in client.messages.batches.results(batch_id):
+        custom_id = entry.custom_id
+        result = entry.result
+
+        if result.type != "succeeded":
+            log.error(
+                "Batch request %s failed: type=%s",
+                custom_id, result.type,
+            )
+            results[custom_id] = None
+            failed += 1
+            continue
+
+        message = result.message
+        text = message.content[0].text if message.content else ""
+        try:
+            parsed = _parse_json_response(text)
+            results[custom_id] = {
+                "speeches": parsed.get("speeches", []),
+                "commitments": parsed.get("commitments", []),
+            }
+            succeeded += 1
+        except Exception as e:
+            log.error("Failed to parse batch result %s: %s", custom_id, e)
+            results[custom_id] = None
+            failed += 1
+
+        # Surface cache hit info from the first few entries to confirm
+        # caching is working in batch mode too.
+        if succeeded <= 3:
+            usage = getattr(message, "usage", None)
+            if usage:
+                read = getattr(usage, "cache_read_input_tokens", 0) or 0
+                write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+                if read or write:
+                    log.info(
+                        "  cache[batch %s]: read=%d write=%d",
+                        custom_id, read, write,
+                    )
+
+    log.info(
+        "Batch %s parsed: %d succeeded, %d failed",
+        batch_id, succeeded, failed,
+    )
+    return results

--- a/scripts/pipeline/summarizer.py
+++ b/scripts/pipeline/summarizer.py
@@ -7,7 +7,7 @@ import logging
 import re
 from typing import Dict, List, Optional
 
-from .prompts import SUMMARY_SYSTEM, SUMMARY_PROMPT
+from .prompts import SUMMARY_SYSTEM, SUMMARY_INSTRUCTIONS, SUMMARY_INPUT_TEMPLATE
 
 log = logging.getLogger("pipeline.summarizer")
 
@@ -72,12 +72,27 @@ def summarize_thread(
 
     formatted = "\n\n---\n\n".join(_format_speech_for_summary(s) for s in speeches)
 
-    prompt = SUMMARY_PROMPT.format(
+    user_input = SUMMARY_INPUT_TEMPLATE.format(
         house=meeting.get("house", ""),
         meeting=meeting.get("meeting", ""),
         topic=thread_info.get("topic", ""),
         speeches=formatted,
     )
+
+    # Static rules / NG-OK examples / output format are sent as a separate
+    # content block with cache_control. Per-thread variable content (committee
+    # + topic + speeches) lives in the second block.
+    messages = [{
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": SUMMARY_INSTRUCTIONS,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": user_input},
+        ],
+    }]
 
     log.info(
         "Summarizing thread '%s' (%d speeches)",
@@ -88,11 +103,24 @@ def summarize_thread(
         model=model,
         max_tokens=8192,
         system=SUMMARY_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
+        messages=messages,
     )
+
+    _log_cache_usage(response)
 
     result = _parse_json_response(response.content[0].text)
     return {
         "speeches": result.get("speeches", []),
         "commitments": result.get("commitments", []),
     }
+
+
+def _log_cache_usage(response) -> None:
+    """Log prompt cache hit/write stats so we can verify caching works."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    read = getattr(usage, "cache_read_input_tokens", 0) or 0
+    write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    if read or write:
+        log.info("  cache[summary]: read=%d write=%d", read, write)

--- a/scripts/sources/base.py
+++ b/scripts/sources/base.py
@@ -117,6 +117,40 @@ class SourceAdapter(ABC):
 
         return filepath
 
+    def write_output_by_meeting_date(
+        self,
+        result: FetchResult,
+        output_dir: str = "data/raw",
+    ) -> list[tuple[str, str, int]]:
+        """Split a multi-date FetchResult by meeting date and write per-date files.
+
+        Returns a list of (meeting_date, filepath, speech_count) tuples for
+        each date that had at least one meeting. Each output file uses the
+        single-date filename convention (e.g. ``ndl-2026-04-10.json``) so the
+        downstream summarizer can pick it up without changes.
+        """
+        from collections import defaultdict
+
+        by_date: dict[str, list] = defaultdict(list)
+        for meeting in result.meetings:
+            if meeting.date:
+                by_date[meeting.date].append(meeting)
+
+        written: list[tuple[str, str, int]] = []
+        for meeting_date, meetings in sorted(by_date.items()):
+            single = FetchResult(
+                source=result.source,
+                fetched_at=result.fetched_at,
+                date_from=meeting_date,
+                date_until=meeting_date,
+                total_speeches=sum(len(m.speeches) for m in meetings),
+                meetings=meetings,
+            )
+            filepath = self.write_output(single, output_dir=output_dir)
+            written.append((meeting_date, filepath, single.total_speeches))
+
+        return written
+
 
 def _meeting_to_dict(m: RawMeeting) -> dict:
     """Convert RawMeeting to the dict format expected by the pipeline.

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -320,6 +320,36 @@ def process_meeting(
     return threads, thread_counter
 
 
+def collect_processed_meeting_ids(threads_path: str) -> set[str]:
+    """Recover the set of meeting_ids already represented in a threads file.
+
+    The thread_id encodes the meeting via a 6-char hash of meeting_id, so we
+    cannot recover the meeting_id directly. Instead we rely on the convention
+    that every thread carries the meeting_id derivable from (committee, house,
+    date) — we reconstruct candidate hashes and compare. To keep this robust
+    we additionally treat the presence of a per-meeting thread as a marker.
+
+    Returns a set of meeting_id hash prefixes (6 chars) that are already
+    represented in the file.
+    """
+    if not os.path.exists(threads_path):
+        return set()
+    try:
+        with open(threads_path, "r", encoding="utf-8") as f:
+            threads = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("Could not read %s for resume: %s", threads_path, e)
+        return set()
+    # Thread IDs look like ``t_YYYYMMDD_<6hex>_<index>``. Extract the hash.
+    hashes: set[str] = set()
+    for t in threads:
+        tid = t.get("id", "")
+        parts = tid.split("_")
+        if len(parts) >= 3:
+            hashes.add(parts[2])
+    return hashes
+
+
 def run_pipeline(
     date_str: str,
     meeting_filter: Optional[str] = None,
@@ -368,11 +398,36 @@ def run_pipeline(
         return
 
     # Progress tracking
+    output_path = os.path.join(output_dir, f"{date_str}.json")
     progress_path = os.path.join(output_dir, f"{date_str}.progress.json")
+
+    # Auto-resume: if the threads file already exists, treat already-summarized
+    # meetings as completed so we only spend API calls on new ones. This keeps
+    # the daily window-fetch idempotent without requiring callers to pass --resume.
+    auto_resume = not resume and os.path.exists(output_path)
+
     if resume:
         progress = load_progress(progress_path)
-        # Clear failed list so they get retried
         progress["failed"] = []
+    elif auto_resume:
+        progress = load_progress(progress_path)
+        progress["failed"] = []
+        # Seed completed list from existing threads when the progress file is
+        # missing (it's deleted on clean completion).
+        if not progress["completed"]:
+            existing_hashes = collect_processed_meeting_ids(output_path)
+            for m in meetings:
+                mid = m.get("meetingId", "")
+                if not mid:
+                    continue
+                h = hashlib.sha256(mid.encode("utf-8")).hexdigest()[:6]
+                if h in existing_hashes:
+                    progress["completed"].append(mid)
+            if progress["completed"]:
+                log.info(
+                    "Auto-resume: %d meeting(s) already represented in %s",
+                    len(progress["completed"]), output_path,
+                )
     else:
         progress = {"completed": [], "failed": []}
 
@@ -385,13 +440,17 @@ def run_pipeline(
     all_threads = []
     thread_counter = 0
 
-    # On resume, load previously generated threads
-    output_path = os.path.join(output_dir, f"{date_str}.json")
-    if resume and os.path.exists(output_path):
+    # On resume (explicit or auto), load previously generated threads so new
+    # meetings get appended instead of overwriting the file.
+    if (resume or auto_resume) and os.path.exists(output_path):
         with open(output_path, "r", encoding="utf-8") as f:
             all_threads = json.load(f)
         thread_counter = len(all_threads)
-        log.info("Resumed with %d existing threads", len(all_threads))
+        log.info(
+            "%s with %d existing threads",
+            "Resumed" if resume else "Auto-resumed",
+            len(all_threads),
+        )
 
     for meeting in meetings:
         meeting_id = meeting.get("meetingId", "unknown")

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -30,7 +30,13 @@ load_dotenv()
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from pipeline.grouper import group_meeting, extract_meeting_outcome
-from pipeline.summarizer import summarize_thread
+from pipeline.summarizer import (
+    summarize_thread,
+    build_summary_request,
+    submit_summary_batch,
+    poll_summary_batch,
+    fetch_summary_results,
+)
 from pipeline.members import extract_member, load_members, save_members
 from pipeline.linker import link_threads
 
@@ -320,6 +326,172 @@ def process_meeting(
     return threads, thread_counter
 
 
+# ---------------------------------------------------------------------------
+# Batch-mode helpers (SUMMARY phase only)
+#
+# Grouping and outcome extraction stay synchronous because they each emit one
+# small call per meeting. The summarization phase emits 3+ calls per meeting
+# with large repeated prompts — that's where the 50% Batches API discount
+# (stackable with prompt caching) actually moves the needle.
+# ---------------------------------------------------------------------------
+
+def make_batch_custom_id(meeting_id: str, thread_idx: int) -> str:
+    """Build an ASCII custom_id for a thread's batch request.
+
+    Meeting IDs contain Japanese characters; the Batches API requires
+    ``custom_id`` to match ``^[a-zA-Z0-9_-]{1,64}$``. We use a 12-hex-char
+    SHA256 prefix which is collision-safe for any plausible batch size.
+    """
+    h = hashlib.sha256(meeting_id.encode("utf-8")).hexdigest()[:12]
+    return f"s_{h}_{thread_idx:02d}"
+
+
+def prepare_meeting_for_batch(
+    client,
+    meeting: dict,
+    model: str,
+) -> dict:
+    """Run grouping + outcome extraction for one meeting (synchronous).
+
+    Returns a dict with the data needed to (a) build the per-thread batch
+    requests and (b) re-assemble threads after the batch returns.
+    """
+    meeting_id = meeting.get("meetingId", "unknown")
+    speeches = meeting.get("speeches", [])
+    raw_lookup = build_speech_lookup(speeches)
+
+    thread_infos = group_meeting(client, meeting, model=model)
+    time.sleep(1)
+    meeting_outcome = extract_meeting_outcome(client, meeting, model=model)
+    time.sleep(1)
+
+    pending = []
+    for idx, thread_info in enumerate(thread_infos):
+        orders = thread_info.get("speechOrders", [])
+        thread_speeches = [raw_lookup[o] for o in orders if o in raw_lookup]
+        if not thread_speeches:
+            log.warning(
+                "No speeches for thread '%s' in %s",
+                thread_info.get("topic"), meeting_id,
+            )
+            continue
+        pending.append({
+            "custom_id": make_batch_custom_id(meeting_id, idx),
+            "meeting": meeting,
+            "thread_info": thread_info,
+            "thread_speeches": thread_speeches,
+            "raw_lookup": raw_lookup,
+        })
+
+    return {
+        "meeting_id": meeting_id,
+        "thread_infos": thread_infos,
+        "outcome": meeting_outcome,
+        "pending": pending,
+    }
+
+
+def run_batch_phase(
+    client,
+    meetings: List[dict],
+    progress: dict,
+    members: Dict[str, dict],
+    model: str,
+    date_str: str,
+    thread_counter: int,
+    batch_timeout_seconds: int = 5400,  # 90 min
+    batch_poll_seconds: int = 30,
+) -> tuple:
+    """Process meetings via Batches API for the summary phase.
+
+    Returns ``(new_threads, updated_thread_counter, completed_meeting_ids)``.
+    """
+    # Phase 1: synchronously group + extract outcome for every new meeting.
+    prepared_meetings: list[dict] = []
+    all_pending: list[dict] = []
+
+    for meeting in meetings:
+        meeting_id = meeting.get("meetingId", "unknown")
+        if meeting_id in progress["completed"]:
+            log.info("Skipping already completed: %s", meeting_id)
+            continue
+
+        log.info("Preparing for batch: %s", meeting_id)
+        try:
+            prep = prepare_meeting_for_batch(client, meeting, model)
+        except Exception as e:
+            log.error("Failed to prepare %s: %s", meeting_id, e)
+            progress["failed"].append(meeting_id)
+            continue
+
+        prepared_meetings.append(prep)
+        all_pending.extend(prep["pending"])
+
+    if not all_pending:
+        log.info("Batch phase: nothing to summarize")
+        return [], thread_counter, []
+
+    # Phase 2: submit + poll + fetch.
+    requests = [
+        build_summary_request(
+            p["meeting"], p["thread_info"], p["thread_speeches"],
+            p["custom_id"], model,
+        )
+        for p in all_pending
+    ]
+    log.info("Submitting %d summary requests via Batches API", len(requests))
+    batch_id = submit_summary_batch(client, requests)
+    poll_summary_batch(
+        client, batch_id,
+        timeout_seconds=batch_timeout_seconds,
+        poll_interval_seconds=batch_poll_seconds,
+    )
+    results = fetch_summary_results(client, batch_id)
+
+    # Phase 3: assemble threads in deterministic order (matches sync mode).
+    new_threads: list = []
+    completed_meeting_ids: list = []
+
+    for prep in prepared_meetings:
+        meeting_id = prep["meeting_id"]
+        outcome = prep["outcome"]
+        thread_infos = prep["thread_infos"]
+
+        for p in prep["pending"]:
+            result = results.get(p["custom_id"])
+            if not result:
+                log.warning(
+                    "No result for %s (thread '%s'); skipping",
+                    p["custom_id"], p["thread_info"].get("topic"),
+                )
+                continue
+
+            thread_counter += 1
+            thread_id = make_thread_id(date_str, meeting_id, thread_counter)
+            thread = assemble_thread(
+                p["meeting"], p["thread_info"], result["speeches"],
+                p["raw_lookup"], members, thread_id,
+            )
+            if not thread:
+                continue
+
+            is_last = (p["thread_info"] is thread_infos[-1])
+            thread["outcome"] = {
+                "result": outcome.get("result") if is_last else None,
+                "resolution": outcome.get("resolution") if is_last else None,
+                "commitments": result["commitments"] or [],
+                "status": outcome.get("status", "ongoing"),
+            }
+            new_threads.append(thread)
+
+        # Mark the meeting as completed even if some of its threads failed —
+        # matches the sync path, which catches per-thread exceptions inside
+        # the meeting loop and still records the meeting as done.
+        completed_meeting_ids.append(meeting_id)
+
+    return new_threads, thread_counter, completed_meeting_ids
+
+
 def collect_processed_meeting_ids(threads_path: str) -> set[str]:
     """Recover the set of meeting_ids already represented in a threads file.
 
@@ -360,6 +532,9 @@ def run_pipeline(
     resume: bool = False,
     dry_run: bool = False,
     verbose: bool = False,
+    batch: bool = False,
+    batch_timeout_seconds: int = 5400,
+    batch_poll_seconds: int = 30,
 ) -> None:
     """Run the full summarization pipeline for a given date."""
     # Load raw data — collect meetings from all source files for this date
@@ -452,30 +627,51 @@ def run_pipeline(
             len(all_threads),
         )
 
-    for meeting in meetings:
-        meeting_id = meeting.get("meetingId", "unknown")
-
-        if meeting_id in progress["completed"]:
-            log.info("Skipping already completed: %s", meeting_id)
-            continue
-
-        log.info("Processing: %s", meeting_id)
-
+    if batch:
         try:
-            threads, thread_counter = process_meeting(
-                client, meeting, members, model, date_str, thread_counter,
+            new_threads, thread_counter, completed_ids = run_batch_phase(
+                client, meetings, progress, members, model, date_str,
+                thread_counter,
+                batch_timeout_seconds=batch_timeout_seconds,
+                batch_poll_seconds=batch_poll_seconds,
             )
-            all_threads.extend(threads)
-            progress["completed"].append(meeting_id)
+            all_threads.extend(new_threads)
+            for mid in completed_ids:
+                if mid not in progress["completed"]:
+                    progress["completed"].append(mid)
             save_progress(progress, progress_path)
-            log.info(
-                "Completed %s — %d threads", meeting_id, len(threads),
-            )
+            log.info("Batch phase: +%d threads from %d meeting(s)",
+                     len(new_threads), len(completed_ids))
         except Exception as e:
-            log.error("Failed to process %s: %s", meeting_id, e)
-            progress["failed"].append(meeting_id)
-            save_progress(progress, progress_path)
-            continue
+            log.error("Batch phase failed: %s", e)
+            # Don't mark any meetings completed on a batch-level failure —
+            # they'll be retried on the next run.
+            raise
+    else:
+        for meeting in meetings:
+            meeting_id = meeting.get("meetingId", "unknown")
+
+            if meeting_id in progress["completed"]:
+                log.info("Skipping already completed: %s", meeting_id)
+                continue
+
+            log.info("Processing: %s", meeting_id)
+
+            try:
+                threads, thread_counter = process_meeting(
+                    client, meeting, members, model, date_str, thread_counter,
+                )
+                all_threads.extend(threads)
+                progress["completed"].append(meeting_id)
+                save_progress(progress, progress_path)
+                log.info(
+                    "Completed %s — %d threads", meeting_id, len(threads),
+                )
+            except Exception as e:
+                log.error("Failed to process %s: %s", meeting_id, e)
+                progress["failed"].append(meeting_id)
+                save_progress(progress, progress_path)
+                continue
 
     # Cross-thread linking
     if all_threads:
@@ -549,6 +745,19 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--resume", action="store_true", help="Resume from last checkpoint")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be processed")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
+    parser.add_argument(
+        "--batch", action="store_true",
+        help="Use Message Batches API for the summary phase (50%% cost discount, "
+             "stackable with prompt caching). Polls until results are ready.",
+    )
+    parser.add_argument(
+        "--batch-timeout", type=int, default=5400,
+        help="Max seconds to wait for batch completion (default: 5400 = 90min)",
+    )
+    parser.add_argument(
+        "--batch-poll", type=int, default=30,
+        help="Seconds between batch status polls (default: 30)",
+    )
 
     return parser.parse_args(argv)
 
@@ -571,6 +780,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         resume=args.resume,
         dry_run=args.dry_run,
         verbose=args.verbose,
+        batch=args.batch,
+        batch_timeout_seconds=args.batch_timeout,
+        batch_poll_seconds=args.batch_poll,
     )
 
 


### PR DESCRIPTION
## Summary
このPRには3つのコミットが含まれます。

### 1. パイプラインのリジリエンス強化 (`04bf32a`)
- 各 fetcher (NDL/Kantei/Council) に `--lookback-days N` を追加し、複数日分の応答を会議日別 raw ファイルに分割書き出し。
- `summarize.py` を auto-resume 化し、`thread_id` の hash prefix から既処理 meeting を逆算。
- `daily-batch.yml` を「単日処理」から「30 日ウィンドウ + 日付ループ + enrich-news + 新規スレッド数監視」に再構成。
- ニュース付与 (`scripts/enrich-news.py`) を初めて日次バッチに組み込む。

### 2. Prompt Caching でコスト削減 (`a06dedf`)
- `prompts.py` の GROUPING / SUMMARY を `*_INSTRUCTIONS` (静的、~800〜1300 tokens) と `*_INPUT_TEMPLATE` (変数部) に分割
- 静的ブロックを `cache_control: ephemeral` でマーキング → 5 分以内の連続呼び出しで cache 読み出し ~10% コスト
- **ルール本文は一字一句変更なし**（中立性・再現性の保護）

### 3. SUMMARY を Message Batches API 経由に (`0ed9443`)
- `summarize.py --batch` フラグ追加。SUMMARY 呼び出しのみバッチ化（GROUPING/OUTCOME は同期維持）
- 1 ワークフロー完結（submit → poll → fetch → assemble）、デフォルト 90 分タイムアウト、30 秒間隔ポーリング
- **50% 入出力割引 × Prompt Caching ~90% 割引 = キャッシュヒット部分は実質 ~5% コスト**
- `custom_id` は meeting_id の SHA256 12 文字 prefix（API は ASCII 制約、meeting_id は日本語）
- workflow も `--batch` 起動に変更

## 背景
2026-05-22 の監査で、daily-batch は 30 連続 success だったにもかかわらず 4/9 以降の新規スレッドはほぼゼロだったことが判明。NDL API には同期間に **5,769 件** が掲載されていたが、バッチが「前日 1 日固定」で取りに行く設計だったため遡及掲載分を全部取り逃していた。直近 1 ヶ月で生成された 14 スレッドはすべて news=0 でもあった (enrich-news が workflow に未組込)。

## コスト試算
- **修正前**: フル料金 × 30 連続「実取得 0」コミットによる無駄な CI 実行
- **修正後（キャッシュヒット時）**:
  - Input tokens: cached portion × 0.5 (batch) × 0.1 (cache) = **~5% コスト**
  - Output tokens: × 0.5 (batch) = **50% コスト**
  - 取り逃していた 30 日分のキャッチアップを含めても累積で大幅減

## Test plan
- [x] `python scripts/fetch_ndl.py --lookback-days 30` → 8 日付ファイル生成、4/22(300sp), 4/23(185sp), 4/28(111sp) 等の未取得日を確認
- [x] `python scripts/fetch_ndl.py --lookback-days -1` → バリデーションでエラー
- [x] `python scripts/summarize.py --date 2026-04-22 --batch --dry-run` → 2 meetings 認識
- [x] 全 Python ファイル `py_compile`、`.github/workflows/daily-batch.yml` YAML 妥当
- [x] Prompt Caching: GROUPING / SUMMARY の構造分割 + cache_control 追加
- [x] Batches API: submit/poll/fetch ヘルパー実装、custom_id 設計、エラー時の roll-forward 設計
- [ ] **マージ後 manual `workflow_dispatch`**: end-to-end + Batch API + cache hit ログ確認

## Risks
- **初回実行コスト**: 取り逃していた 30 日分（推定 30-50 スレッドぶん）の要約を初回バッチで処理。これは一度きりのキャッチアップ。
- **Batches API のタイムアウト**: 30 分以内に終わるのが普通だが、Anthropic 側の負荷で長引く可能性 → 90 分上限。タイムアウト時は次回再試行。
- **静的ブロック順序変更によるフォーマット遵守**: まれに LLM の出力フォーマットが揺らぐ可能性。初回 CI ログでサンプル確認推奨。
- **enrich-news 失敗時**: `continue-on-error: true` で握り潰し（外部 best-effort）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)