### PR TITLE
feat(enrich-news): Claude-based relevance ranker for Bing News candidates

### DIFF
--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -101,16 +101,21 @@ jobs:
           done
 
       # ----- Enrich threads with news articles (Bing News RSS) -----
+      # --rank-with-claude filters Bing candidates through a Haiku 4.5 call
+      # so we don't attach semantically-similar-but-unrelated articles
+      # (e.g. "AI絵画展" for an "AI規制" thread). Best-effort; if the call
+      # fails, the script falls back to the top Bing results.
       - name: Enrich threads with news
         if: steps.dates.outputs.list != ''
         continue-on-error: true
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DATES_LIST: ${{ steps.dates.outputs.list }}
         run: |
           for d in $DATES_LIST; do
             if [ -f "data/threads/$d.json" ]; then
               echo "::group::Enrich $d"
-              python scripts/enrich-news.py --date "$d" || true
+              python scripts/enrich-news.py --date "$d" --rank-with-claude || true
               echo "::endgroup::"
             fi
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,20 @@ Summaries must express the **content of the speech itself**, not report on it.
 - **Bad** (reporting style): "Pointed out that the AI definition is too vague and requested comparison with EU."
 - **Good** (direct style): "The AI definition is too vague — recommendation engines could fall under regulation. Show the comparison with EU and impact estimates."
 
+## Summary Layer Invariants (Critical for Neutrality)
+
+The summary pipeline (`scripts/summarize.py` + `scripts/pipeline/grouper.py` + `scripts/pipeline/summarizer.py` + `scripts/pipeline/prompts.py`) is the core of OpenGIKAI's political-neutrality guarantee. The following are **non-negotiable**:
+
+1. **Stateless**: No Memory tool, no carrying state across runs. A speech summarized today must produce the same output if re-summarized tomorrow on the same model.
+2. **Deterministic**: temperature=0, no agent loops, no tool calls that branch on intermediate results. Same input → same output.
+3. **Prompt-only behavior**: All summarization rules live in `prompts.py` and are open-source. No retrieval-augmented prompts, no examples sourced from prior runs.
+4. **No conversational UI inside OpenGIKAI's domain**: Chat answers are non-deterministic and break the "Claude AI summary" transparency label. External MCP server (separate Vercel project) is fine because clients bring their own LLM and we expose only deterministic JSON.
+
+### What IS allowed
+Auxiliary information layers (news enrichment, members extraction, sitemap generation, OGP image generation) may use LLM/agent patterns. They affect *which* context surfaces alongside a thread, not *what* a speech says. Example: `scripts/pipeline/news_ranker.py` uses Claude with temperature=0 and prompt caching to filter Bing News candidates — that is auxiliary, not summary.
+
+When adding any new Claude-using script, ask yourself: **does this change what a speech is summarized to say?** If yes → must obey the invariants above. If no → reasonable freedom (still keep it deterministic where practical).
+
 ## Development Commands
 
 ```bash

--- a/scripts/enrich-news.py
+++ b/scripts/enrich-news.py
@@ -4,10 +4,19 @@
 For each thread, searches Bing News by topic keywords, extracts article
 metadata and OGP images, then stores them in context.news[].
 
+With --rank-with-claude, the candidate articles are passed through a
+short Claude API call (haiku, temperature=0) that picks the most-relevant
+ones and discards the noise — Bing News' first results often include
+semantically-similar-but-actually-unrelated articles.
+
 Usage:
     python scripts/enrich-news.py --date 2025-01-25
-    python scripts/enrich-news.py --all          # process all thread files
-    python scripts/enrich-news.py --all --dry-run # preview without writing
+    python scripts/enrich-news.py --all
+    python scripts/enrich-news.py --all --dry-run
+    python scripts/enrich-news.py --date 2026-04-22 --rank-with-claude
+
+This is an auxiliary-information layer. The neutrality-critical summary
+pipeline (scripts/pipeline/summarizer.py) stays LLM-deterministic.
 """
 
 from __future__ import annotations
@@ -17,6 +26,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from datetime import date, timedelta
 from urllib.parse import quote, unquote
@@ -34,6 +44,9 @@ HEADERS = {
     ),
 }
 MAX_ARTICLES_PER_THREAD = 3
+# When --rank-with-claude is on, pull this many candidates from Bing so
+# the ranker has room to filter out unrelated hits.
+RANK_POOL_SIZE = 8
 BING_DELAY = 1.0  # seconds between Bing requests
 OGP_TIMEOUT = 5
 OGP_DELAY = 0.3
@@ -122,8 +135,17 @@ def build_query(thread: dict) -> str:
     return query
 
 
-def enrich_thread(thread: dict, dry_run: bool = False) -> int:
-    """Add news articles to a single thread. Returns count of articles added."""
+def enrich_thread(
+    thread: dict,
+    dry_run: bool = False,
+    rank_client=None,
+) -> int:
+    """Add news articles to a single thread. Returns count of articles added.
+
+    If ``rank_client`` is provided, candidate articles are filtered with
+    Claude relevance ranking; otherwise the first ``MAX_ARTICLES_PER_THREAD``
+    Bing results are kept verbatim.
+    """
     # Skip if already enriched
     context = thread.get("context", {})
     if context.get("news"):
@@ -138,6 +160,14 @@ def enrich_thread(thread: dict, dry_run: bool = False) -> int:
 
     if not articles:
         return 0
+
+    if rank_client is not None:
+        # Lazy import keeps the module usable on machines without `anthropic`.
+        from pipeline.news_ranker import rank_news_articles
+        articles = rank_news_articles(
+            rank_client, thread, articles[:RANK_POOL_SIZE],
+            max_keep=MAX_ARTICLES_PER_THREAD,
+        )
 
     news_items = []
     for article in articles[:MAX_ARTICLES_PER_THREAD]:
@@ -164,7 +194,11 @@ def enrich_thread(thread: dict, dry_run: bool = False) -> int:
     return len(news_items)
 
 
-def process_file(filepath: str, dry_run: bool = False) -> tuple[int, int]:
+def process_file(
+    filepath: str,
+    dry_run: bool = False,
+    rank_client=None,
+) -> tuple[int, int]:
     """Process a single thread file. Returns (threads_enriched, articles_added)."""
     with open(filepath, "r", encoding="utf-8") as f:
         threads = json.load(f)
@@ -173,7 +207,7 @@ def process_file(filepath: str, dry_run: bool = False) -> tuple[int, int]:
     total_articles = 0
 
     for thread in threads:
-        count = enrich_thread(thread, dry_run=dry_run)
+        count = enrich_thread(thread, dry_run=dry_run, rank_client=rank_client)
         if count > 0:
             total_enriched += 1
             total_articles += count
@@ -206,6 +240,11 @@ def main():
     parser.add_argument("--all", action="store_true", help="Process all thread files")
     parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
     parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument(
+        "--rank-with-claude", action="store_true",
+        help="Filter Bing News candidates with a Claude relevance ranker. "
+             "Requires ANTHROPIC_API_KEY in the environment.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -224,6 +263,21 @@ def main():
     else:
         parser.error("Specify --date or --all")
 
+    rank_client = None
+    if args.rank_with_claude:
+        # Add scripts/ to sys.path so `pipeline.news_ranker` resolves the
+        # same way the summarizer does.
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        try:
+            import anthropic
+            from dotenv import load_dotenv
+            load_dotenv()
+            rank_client = anthropic.Anthropic()
+        except ImportError as e:
+            parser.error(
+                f"--rank-with-claude requires anthropic and python-dotenv: {e}"
+            )
+
     grand_enriched = 0
     grand_articles = 0
 
@@ -233,7 +287,9 @@ def main():
             continue
 
         log.info("Processing %s", filepath)
-        enriched, articles = process_file(filepath, dry_run=args.dry_run)
+        enriched, articles = process_file(
+            filepath, dry_run=args.dry_run, rank_client=rank_client,
+        )
         grand_enriched += enriched
         grand_articles += articles
 

--- a/scripts/pipeline/news_ranker.py
+++ b/scripts/pipeline/news_ranker.py
@@ -1,0 +1,207 @@
+"""Relevance ranking for news articles attached to threads.
+
+Given a thread and a candidate list of news articles (from Bing News RSS),
+ask Claude to pick the most-relevant ones and return them in order.
+
+Why this exists:
+    Bing News' first results for a parliamentary topic often include
+    semantically-similar-but-actually-unrelated articles (e.g. "AI絵画展"
+    when querying "AI規制"). A short Claude call sorts the noise out.
+
+Neutrality:
+    This is a helper layer for *auxiliary* context (news links), not for
+    the summary itself. The summary layer must remain deterministic and
+    LLM-free at request time — see CLAUDE.md "Summary Layer Invariants".
+    Even here, we use temperature=0 and a fully-cached system prompt so
+    re-runs over the same input produce the same selection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Optional
+
+log = logging.getLogger("pipeline.news_ranker")
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+# Kept in this module (not pipeline/prompts.py) because it isn't part of
+# the summarization pipeline that prompts.py exists to make auditable —
+# this prompt only affects which news links surface, not summary text.
+RANKER_SYSTEM = """\
+あなたは国会の議論スレッドに関連するニュース記事を選別するアシスタントです。
+政治的に中立な立場で、与党・野党を区別せず同じ基準で処理してください。"""
+
+RANKER_INSTRUCTIONS = """\
+与えられたニュース記事候補から、議論スレッドの「議題そのもの」と関連する記事を選んでください。
+
+## 関連性の判定ルール
+- 議題で直接議論されている法案・政策・事件に関する報道 → 関連あり
+- 同じキーワードを含むが議題と無関係な記事 (例: 議題「AI規制」に対する「AI絵画展」) → 関連なし
+- 議題の背景や前提となる事件・データを報じた記事 → 関連あり
+- 単なる人物紹介・選挙速報・無関係なゴシップ → 関連なし
+- 政党や政治家への党派的な評価記事は採用しない (中立性のため)
+
+## 採用候補について
+- 最大3件まで採用
+- 関連性が同程度の場合は新しい報道を優先
+- 関連する記事が0件なら空配列を返してよい (無理に埋めない)
+
+## 出力 (JSONのみ、他のテキストは不要)
+```json
+{
+  "selected_indices": [0, 3, 7],
+  "reasoning": "短い理由 (50字以内)"
+}
+```
+indicesは 0 始まり。順序は関連性の高い順。"""
+
+
+def _format_article_for_ranking(idx: int, article: dict) -> str:
+    """Format one article candidate for the ranker prompt."""
+    title = article.get("title", "")
+    source = article.get("source", "")
+    pub_date = article.get("pubDate", "")
+    return f"[{idx}] {title}\n  source: {source} / pubDate: {pub_date}"
+
+
+def _format_thread_context(thread: dict) -> str:
+    """Summarize the thread's topic for the ranker, without leaking full summaries."""
+    parts = [
+        f"議題: {thread.get('topic', '')}",
+        f"委員会: {thread.get('committee', '')}",
+        f"日付: {thread.get('date', '')}",
+    ]
+    summary = thread.get("summary", "")
+    if summary:
+        parts.append(f"スレッド要約: {summary}")
+    ctx = thread.get("context") or {}
+    description = ctx.get("description") if isinstance(ctx, dict) else None
+    if description:
+        parts.append(f"背景: {description}")
+    return "\n".join(parts)
+
+
+def _parse_json_response(text: str) -> dict:
+    """Extract JSON from Claude's response, tolerating markdown fences."""
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(text[start:end + 1])
+        except json.JSONDecodeError:
+            pass
+    raise ValueError(f"Could not parse JSON from ranker response: {text[:200]}...")
+
+
+def rank_news_articles(
+    client,
+    thread: dict,
+    candidates: list[dict],
+    max_keep: int = 3,
+    model: str = DEFAULT_MODEL,
+) -> list[dict]:
+    """Pick the most-relevant news articles for a thread.
+
+    Returns the surviving subset of ``candidates`` in the order Claude
+    chose. Falls back to ``candidates[:max_keep]`` if anything goes wrong —
+    news enrichment is best-effort.
+    """
+    if not candidates:
+        return []
+    # Below ~3 candidates there's nothing meaningful to filter; save an API
+    # call and return as-is.
+    if len(candidates) <= max_keep:
+        return candidates[:max_keep]
+
+    user_input = (
+        f"## スレッド情報\n{_format_thread_context(thread)}\n\n"
+        "## ニュース記事候補\n"
+        + "\n".join(_format_article_for_ranking(i, a) for i, a in enumerate(candidates))
+    )
+
+    messages = [{
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": RANKER_INSTRUCTIONS,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": user_input},
+        ],
+    }]
+
+    try:
+        response = client.messages.create(
+            model=model,
+            max_tokens=512,
+            temperature=0,
+            system=RANKER_SYSTEM,
+            messages=messages,
+        )
+    except Exception as e:
+        log.warning("Ranker API call failed for '%s': %s — falling back",
+                    thread.get("topic", "?"), e)
+        return candidates[:max_keep]
+
+    _log_cache_usage(response)
+
+    text = response.content[0].text if response.content else ""
+    try:
+        parsed = _parse_json_response(text)
+    except ValueError as e:
+        log.warning("Ranker output unparseable for '%s': %s — falling back",
+                    thread.get("topic", "?"), e)
+        return candidates[:max_keep]
+
+    indices = parsed.get("selected_indices", [])
+    if not isinstance(indices, list):
+        return candidates[:max_keep]
+
+    selected: list[dict] = []
+    seen: set[int] = set()
+    for idx in indices:
+        if not isinstance(idx, int) or idx < 0 or idx >= len(candidates):
+            continue
+        if idx in seen:
+            continue
+        seen.add(idx)
+        selected.append(candidates[idx])
+        if len(selected) >= max_keep:
+            break
+
+    reasoning = parsed.get("reasoning") or ""
+    log.info(
+        "  ranker[%s]: kept %d/%d (%s)",
+        thread.get("id", "?")[-10:],
+        len(selected),
+        len(candidates),
+        (reasoning[:50] + "…") if len(reasoning) > 50 else reasoning,
+    )
+
+    return selected
+
+
+def _log_cache_usage(response) -> None:
+    """Log prompt cache hit/write stats so we can verify caching works."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    read = getattr(usage, "cache_read_input_tokens", 0) or 0
+    write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    if read or write:
+        log.info("  cache[ranker]: read=%d write=%d", read, write)


### PR DESCRIPTION
## Summary
- `scripts/pipeline/news_ranker.py` を新規追加。Bing News から取得した記事候補を Claude (Haiku 4.5, temperature=0) で関連度判定して上位 3 件を選別。
- `scripts/enrich-news.py` に `--rank-with-claude` フラグ追加。デフォルト OFF (既存挙動を維持)、ON 時のみ ranker を呼ぶ。
- Bing 候補プールサイズを 3 → 8 に拡大 (ranker が選別できる余地を確保)。
- 失敗時は無関係フォールバック (`articles[:3]`) — ニュース付与は best-effort で workflow を絶対に止めない。
- **CLAUDE.md に「Summary Layer Invariants」セクション追加** — 要約レイヤーの stateless/deterministic/prompt-only 原則と、補助レイヤーで LLM を使ってよい境界を明文化。

## 背景
Bing News RSS はキーワード一致度で並ぶため、議題と表面的に似ているだけの無関係記事 (例: 「AI規制」の議論に「AI絵画展」、「能登半島地震」の議論に過去の地震一般記事) を上位返却することがある。Claude による関連度判定で「議題そのもの」の記事に絞れる。

## 実 API 検証 (2026-05-19, 2 スレッド)
```
thread 「韓国訪問と日韓首脳会談」: Bing 8 件 → ranker 3 件
  ranker reasoning: 「議題の首脳会談そのものの内容・成果・狙いを直接報じた記事。
                   会談の事実と政策合意を扱う報道を優先。」
  選別結果:
    ✓ 高市首相「良好な日韓関係発展させる」 李氏の出身地で首脳会談
    ✓ 日韓首脳会談 狙いは? 双方に「アメリカに頼り切れないかもしれない」
    ✓ 日本主導の原油支援、韓国も参加 日韓首脳19日に合意へ

thread 「週刊誌報道と中傷動画投稿疑惑」: Bing 8 件 → ranker 3 件
  ranker reasoning: 「議題の中心である中傷動画投稿疑惑と総理答弁の整合性に
                   直接関連する報道。」
```

## 中立性ガード (CLAUDE.md 反映)
要約レイヤー (`summarize.py` + `pipeline/grouper.py` + `pipeline/summarizer.py` + `pipeline/prompts.py`) は **non-negotiable な不可侵原則**:
1. **Stateless** — Memory tool 禁止
2. **Deterministic** — temperature=0, agent loop 禁止
3. **Prompt-only** — RAG / 過去ランからの few-shot 禁止
4. **No conversational UI on the OpenGIKAI domain** — MCP server (別 project) は例外

一方、**補助情報レイヤー** (news enrichment, OGP 生成, sitemap 等) は LLM/agent パターンを使ってよい。「議題と並ぶ補助情報を変える」のと「議事録要約そのものを変える」では中立性インパクトが異なるため。

## コスト
- Haiku 4.5: 1 リクエスト約 ~$0.00001 (2KB 入力 + 200 token 出力)
- 30 日分の取りこぼし catch-up (推定 100 スレッド) でも合計 $0.01 未満
- prompt cache が system + instructions block (~1500 tokens) にヒットするので大幅減

## Test plan
- [x] 構文チェック (py_compile 両方 OK)
- [x] フォールバック動作テスト (API 不要パス)
- [x] 実 API テスト (1 ファイル / 2 スレッド / Bing 8→3 選別)
- [x] CLAUDE.md 更新
- [ ] **workflow への組み込みは PR #34 マージ後に別 PR で** (1 行 `--rank-with-claude` 追加するだけ)

## Risks
- Ranker が偽陽性で良い記事を落とすケース → reasoning ログで監視可能、必要なら prompt 調整
- Anthropic API ダウン時 → フォールバックで unranked 結果を採用、workflow は通る
- Bing News レスポンス形式変更 → ranker 以前の問題、別途検知が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)