### PR TITLE
docs: refresh README and CLAUDE.md after this session's pipeline + MCP work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,14 @@ OpenGIKAI (議会) is a public media project that restructures Japanese parliame
 
 ## Tech Stack
 
-- **Frontend**: Next.js 15 (App Router), TypeScript, Tailwind CSS
-- **Deployment**: Vercel (SSG - Static Site Generation)
-- **Data Pipeline**: Python scripts + Claude API (batch processing), with a SourceAdapter abstraction for multi-source ingestion (`scripts/sources/`)
+- **Frontend**: Next.js 16 (App Router), TypeScript, Tailwind CSS. `output: "export"` — fully static, no server runtime at the root.
+- **Deployment**: Two Vercel projects from one repo. Root → SSG frontend at `open-gikai.net`. `apps/mcp/` → dynamic MCP server.
+- **Data Pipeline**: Python scripts + Claude API
+  - Sliding 30-day lookback per run (NDL publishes transcripts with multi-day lag — see `scripts/fetch_ndl.py --lookback-days`).
+  - `summarize.py --batch` uses Anthropic's Message Batches API for the summary phase (50% input/output discount).
+  - System+user prompt instructions cached with `cache_control: ephemeral` (`scripts/pipeline/prompts.py` + `summarizer.py` / `grouper.py`).
+  - `scripts/pipeline/news_ranker.py` (Haiku 4.5) filters Bing News candidates — auxiliary layer only.
+  - SourceAdapter abstraction lives in `scripts/sources/`.
 - **Data Sources**: NDL Diet Records API (`https://kokkai.ndl.go.jp/api/speech`), kantei.go.jp PM press conferences (`https://www.kantei.go.jp/`), cao.go.jp council meeting minutes (`https://www8.cao.go.jp/kisei-kaikaku/kisei/meeting/meeting.html`)
 
 ## Key Design Principles
@@ -41,17 +46,23 @@ When adding any new Claude-using script, ask yourself: **does this change what a
 ## Development Commands
 
 ```bash
-# Install dependencies
+# --- Frontend (repo root) ---
 npm install
-
-# Development server
-npm run dev
-
-# Build
-npm run build
-
-# Lint
+npm run dev      # localhost:3000
+npm run build    # static export → out/
 npm run lint
+
+# --- MCP server (apps/mcp) ---
+cd apps/mcp
+npm install
+npm run dev      # localhost:3100
+npm run build    # prebuild script copies data/ from repo root
+
+# --- Data pipeline (Python) ---
+# Daily-batch.yml runs these in sequence each morning. To replay locally:
+python scripts/fetch_ndl.py --lookback-days 30
+python scripts/summarize.py --date YYYY-MM-DD --batch
+python scripts/enrich-news.py --date YYYY-MM-DD --rank-with-claude
 ```
 
 ## Project Structure
@@ -75,9 +86,13 @@ npm run lint
 The repo hosts **two Vercel projects** pointing at the same GitHub repo:
 
 - Root → frontend SSG (open-gikai.net). `next.config.ts` sets `output: "export"`.
-- `apps/mcp` → dynamic MCP server (mcp.open-gikai.net or similar). Reads the
-  same `data/threads/` and `data/members.json` via `outputFileTracingRoot`
-  pointing at the repo root.
+- `apps/mcp` → dynamic MCP server. A `prebuild` script
+  (`apps/mcp/scripts/copy-data.mjs`) copies `data/threads/` and
+  `data/members.json` from the repo root into `apps/mcp/data/` so they ship
+  with the serverless function bundle. The runtime reads from
+  `process.cwd()/data` — see `apps/mcp/src/lib/data.ts`. We deliberately
+  avoid `outputFileTracingRoot` pointing above the project root because
+  Vercel double-prefixes such absolute paths during deploy.
 
 Because the frontend uses static export, **server-side features (Route
 Handlers, dynamic API routes, middleware) cannot be added under `src/app/`**.

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,10 +23,11 @@
 
 | レイヤー | 技術 |
 |----------|------|
-| フロントエンド | Next.js 15 (App Router)、TypeScript、Tailwind CSS |
-| デプロイ | Vercel（静的サイト生成） |
-| データパイプライン | Python + Claude API |
+| フロントエンド | Next.js 16 (App Router)、TypeScript、Tailwind CSS |
+| デプロイ | Vercel — 同一リポジトリから2つの project: ルートが SSG フロントエンド、`apps/mcp/` が動的 MCP server |
+| データパイプライン | Python + Claude API (Message Batches API + prompt caching) |
 | データソース | [NDL 国会会議録検索システムAPI](https://kokkai.ndl.go.jp/api.html)、[首相官邸](https://www.kantei.go.jp/)、[内閣府 審議会](https://www8.cao.go.jp/kisei-kaikaku/kisei/meeting/meeting.html) |
+| 公開 API | Claude Desktop / Cline / その他エージェント向けの読み取り専用 [MCP server](./apps/mcp/README.md) |
 
 ## はじめかた
 
@@ -35,62 +36,118 @@
 git clone https://github.com/wharfe/open-gikai.git
 cd open-gikai
 
-# 依存パッケージをインストール
+# フロントエンドの依存パッケージをインストール
 npm install
 
-# 開発サーバーを起動
+# フロントエンドの開発サーバーを起動
 npm run dev
 ```
+
+MCP server は `apps/mcp/` 配下の独立した Next.js project で、依存も独自管理です。
+
+```bash
+cd apps/mcp
+npm install
+npm run dev   # http://localhost:3100 で起動
+```
+
+MCP server のデプロイ詳細は [`apps/mcp/README.md`](./apps/mcp/README.md) を参照してください。
 
 ## プロジェクト構成
 
 ```
-├── src/
-│   ├── app/          # Next.js App Router ページ
-│   ├── components/   # Reactコンポーネント
-│   ├── lib/          # ユーティリティ・データ取得
-│   └── types/        # TypeScript型定義
-├── scripts/          # Pythonバッチ処理（ソースアダプター → Claude API → JSON）
-│   └── sources/      # ソースアダプター（NDL、官邸、審議会など）
-├── data/             # SSG用の生成済みJSONデータ
-└── public/           # 静的アセット
+├── src/                  # フロントエンド（Next.js SSG — output: "export"）
+│   ├── app/              # App Router ページ
+│   ├── components/       # React コンポーネント
+│   ├── lib/              # ユーティリティ・データ取得
+│   └── types/            # TypeScript 型定義
+├── apps/
+│   └── mcp/              # MCP server（別 Vercel project、動的 Node ランタイム）
+├── scripts/              # Python バッチ処理
+│   ├── sources/          # ソースアダプター（NDL・官邸・審議会など）
+│   └── pipeline/         # AI パイプライン（グルーピング・要約・ニュース ranker）
+├── data/                 # SSG と MCP server 共有の生成済み JSON
+│   ├── threads/          # 日付別スレッドファイル
+│   └── members.json      # 蓄積される議員レジストリ
+├── public/               # 静的アセット（sitemap, RSS feed 等）
+└── .github/workflows/    # daily-batch.yml（6:00 JST cron）
 ```
+
+フロントエンドは `output: "export"` を使うため、Node ランタイムを必要とするもの（Route Handler、動的 API 等）は `apps/` 配下に置く設計です。
 
 ## 仕組み
 
 ```
-ソース（NDL、官邸、審議会等） → データ取得 → テーマ別グルーピング（Claude API）
-                      → 3レベル要約生成 → 静的JSON出力 → サイトデプロイ
+ソース（NDL、官邸、審議会）
+   ├─► fetch（毎回 30 日のスライディングウィンドウ）
+   │
+   ├─► テーマ別グルーピング                ┐
+   ├─► tension 分類                          │  Claude API
+   ├─► 3レベル要約（Message Batches API）   │  + prompt caching
+   ├─► コミットメント・採決結果抽出           ┘
+   │
+   ├─► 関連ニュース付与（Bing News + Claude 関連度判定）
+   │
+   └─► JSON 生成
+         ├─► フロントエンド SSG → open-gikai.net (Vercel)
+         └─► MCP server         → /api/mcp        (Vercel, apps/mcp)
 ```
 
-1. **デイリーバッチ**: SourceAdapterを通じて各ソース（NDL、官邸、審議会等）から前日のデータを取得
-2. **AI処理**: テーマ別にグルーピング、テンション分類（追及・答弁・再追及など）、3レベルの要約を生成
-3. **静的生成**: Next.js SSG用のJSONファイルを出力
-4. **デプロイ**: Vercelに自動デプロイ
+1. **スライディングウィンドウ取得**: 各実行で過去 30 日を再取得。NDL は議事録を数日〜数週間遅れで掲載するため、「前日のみ」取得では遡及掲載分を取り逃す。
+2. **AI 処理**:
+   - **グルーピング** — 会議ごとに同期呼び出し。発言をテーマ別スレッドに分割。
+   - **要約** — スレッド単位で Message Batches API（入出力 50% 割引）。prompt caching と併用でキャッシュ部分の入力コストは ~10% に。
+   - **採決抽出** — 会議ごとに同期呼び出し。委員長発言から採決結果・附帯決議を抽出。
+3. **ニュース付与**: Bing News でテーマ検索 → Claude Haiku ranker（`scripts/pipeline/news_ranker.py`）が候補から最も関連の高い 3 件を選別。これは補助情報レイヤー — 要約レイヤーとの境界は CLAUDE.md「Summary Layer Invariants」を参照。
+4. **静的生成**: `data/threads/*.json` と `data/members.json` を Next.js SSG が消費して静的 HTML を生成。
+5. **デプロイ**: 同一リポジトリから 2 つの Vercel project（ルート = SSG / `apps/mcp` = 動的 MCP server）。
+6. **監視**: daily-batch のコミットメッセージに `(+N threads)` を付与。7 回連続で 0 が続くと CI warning を発火（緑チェックだけでは見えない fetcher リグレッションを構造的に検知）。
 
 ## データパイプライン
 
 ```bash
-# 1. 各ソースからデータを取得
-python scripts/fetch_ndl.py --date-from 2025-03-14
-python scripts/fetch_kantei.py --date-from 2025-03-14
-python scripts/fetch_council.py --date-from 2025-12-24  # 審議会議事録（PDF）
+# 1. スライディングウィンドウで取得（30日で NDL 遡及掲載を拾う）
+python scripts/fetch_ndl.py     --lookback-days 30
+python scripts/fetch_kantei.py  --lookback-days 30
+python scripts/fetch_council.py --lookback-days 30 --council kisei
+# (... 各 council 分繰り返し。フルリストは daily-batch.yml 参照)
 
-# 2. Claude APIで要約（.envにANTHROPIC_API_KEYが必要）
-python scripts/summarize.py --date 2025-03-14
+# 2. Message Batches API で要約（既存 data/threads/ に対して auto-resume）
+#    .env に ANTHROPIC_API_KEY が必要
+python scripts/summarize.py --date 2026-04-22 --batch
 
-# 3. ビルド・プレビュー
+# 3. ニュース付与 + Claude 関連度判定
+python scripts/enrich-news.py --date 2026-04-22 --rank-with-claude
+
+# 4. sitemap・feed 生成 + バリデーション + SSG ビルド
+node scripts/validate-data.mjs --fix
+node scripts/generate-feeds.js
+node scripts/generate-sitemap.mjs
 npm run build && npx serve out
 ```
 
-設定は `.env.example` を参照してください。
+設定は `.env.example` を参照してください。`.github/workflows/daily-batch.yml` が上記を 6:00 JST に毎日自動実行します。
+
+## MCP Server
+
+OpenGIKAI は読み取り専用の [Model Context Protocol](https://modelcontextprotocol.io) server としても公開しており、Claude Desktop / Cline / MCP 対応エージェントから直接議事録を検索できます。
+
+| Tool | 用途 |
+|------|------|
+| `search_threads` | キーワード・日付範囲・委員会・ソースでスレッド検索 |
+| `get_thread` | スレッドの完全な内容（3レベル要約・原文引用・tension 分類・採決結果） |
+| `get_member` | 議員プロフィール |
+| `list_members` | 議員一覧（氏名・政党フィルタ） |
+| `list_dates` | データのある日付と各日のスレッド数 |
+
+MCP server は `apps/mcp/` 配下にあり、同じリポジトリから 2 つ目の Vercel project としてデプロイされます。**OpenGIKAI 側は LLM 推論コストを負担しません** — クライアント（Claude Desktop 等）が自分の API キーで Claude を呼び、サーバーは JSON を返すだけです。エンドポイント URL と Claude Desktop の設定例は [`apps/mcp/README.md`](./apps/mcp/README.md) を参照してください。
 
 ## 設計原則
 
-- **設計による政治的中立性** — すべての発言を同一のアルゴリズムで処理。編集上の取捨選択なし。プロンプトはオープンソース。
-- **出典の透明性** — すべての要約がNDLの原文議事録にリンク
-- **AIの透明性** — AI生成コンテンツは明確にラベル表示
-- **アクセシビリティ** — 3つの読みやすさレベルで国会審議を身近に
+- **設計による政治的中立性** — すべての発言を同一のアルゴリズムで処理。編集上の取捨選択なし。プロンプトはオープンソース。要約レイヤーは stateless / deterministic / プロンプト挙動のみ（Memory tool・Agent ループ・対話 UI を要約レイヤーに導入しない）— 詳しくは [`CLAUDE.md`](./CLAUDE.md) の「Summary Layer Invariants」を参照。
+- **出典の透明性** — すべての要約が NDL / 官邸 / 審議会の原文にリンク。
+- **AI の透明性** — AI 生成コンテンツは明示的にラベル表示。MCP のレスポンスには `attribution` ブロックを必ず含め、下流エージェントにも明確に伝える。
+- **アクセシビリティ** — 3 つの読みやすさレベルで国会審議を身近に。
 
 ## データソース
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Parliamentary records are public but hard to read. OpenGIKAI makes them accessib
 
 | Layer | Technology |
 |-------|-----------|
-| Frontend | Next.js 15 (App Router), TypeScript, Tailwind CSS |
-| Deployment | Vercel (Static Site Generation) |
-| Data Pipeline | Python + Claude API |
+| Frontend | Next.js 16 (App Router), TypeScript, Tailwind CSS |
+| Deployment | Vercel — two projects from one repo: SSG frontend at the root, dynamic MCP server at `apps/mcp/` |
+| Data Pipeline | Python + Claude API (Message Batches API + prompt caching) |
 | Data Sources | [NDL Diet Records API](https://kokkai.ndl.go.jp/api.html), [kantei.go.jp](https://www.kantei.go.jp/), [cao.go.jp councils](https://www8.cao.go.jp/kisei-kaikaku/kisei/meeting/meeting.html) |
+| Public API | Read-only [MCP server](./apps/mcp/README.md) for Claude Desktop / Cline / custom agents |
 
 ## Getting Started
 
@@ -34,63 +35,118 @@ Parliamentary records are public but hard to read. OpenGIKAI makes them accessib
 git clone https://github.com/wharfe/open-gikai.git
 cd open-gikai
 
-# Install dependencies
+# Install frontend dependencies
 npm install
 
-# Start development server
+# Start the frontend dev server
 npm run dev
 ```
+
+The MCP server is a separate Next.js project under `apps/mcp/` with its own dependencies:
+
+```bash
+cd apps/mcp
+npm install
+npm run dev   # serves on http://localhost:3100
+```
+
+See [`apps/mcp/README.md`](./apps/mcp/README.md) for MCP deployment details.
 
 ## Project Structure
 
 ```
-├── src/
-│   ├── app/          # Next.js App Router pages
-│   ├── components/   # React components
-│   ├── lib/          # Utilities and data fetching
-│   └── types/        # TypeScript type definitions
-├── scripts/          # Python batch processing (source adapters → Claude API → JSON)
-│   └── sources/      # Source adapters (NDL, kantei, council, etc.)
-├── data/             # Generated JSON data for SSG
-└── public/           # Static assets
+├── src/                  # Frontend (Next.js SSG — output: "export")
+│   ├── app/              # App Router pages
+│   ├── components/       # React components
+│   ├── lib/              # Utilities and data fetching
+│   └── types/            # TypeScript type definitions
+├── apps/
+│   └── mcp/              # MCP server (separate Vercel project, dynamic Node runtime)
+├── scripts/              # Python batch processing
+│   ├── sources/          # Source adapters (NDL, kantei, council, …)
+│   └── pipeline/         # AI pipeline (grouping, summarization, news ranker)
+├── data/                 # Generated JSON consumed by both frontend SSG and MCP server
+│   ├── threads/          # Per-date thread files
+│   └── members.json      # Accumulated Diet member registry
+├── public/               # Static assets (incl. sitemap, RSS feed)
+└── .github/workflows/    # daily-batch.yml (6:00 AM JST cron)
 ```
+
+The frontend uses `output: "export"`, so anything requiring a Node runtime (Route Handlers, dynamic APIs) lives under `apps/`.
 
 ## How It Works
 
 ```
-Sources (NDL, kantei, council, ...) → Fetch transcripts → Group by topic (Claude API)
-     → Summarize at 3 levels → Enrich with related news → Generate static JSON → Deploy site
+Sources (NDL, kantei, council)
+   ├─► fetch (sliding 30-day window per run)
+   │
+   ├─► group by topic                  ┐
+   ├─► classify tension                │  Claude API
+   ├─► summarize at 3 levels (Batches) │  + prompt caching
+   ├─► extract commitments / outcomes  ┘
+   │
+   ├─► enrich with related news (Bing News + Claude relevance ranker)
+   │
+   └─► generate JSON
+         ├─► frontend SSG  → open-gikai.net (Vercel)
+         └─► MCP server     → /api/mcp       (Vercel, apps/mcp)
 ```
 
-1. **Daily batch**: Fetches previous day's content from configured sources (NDL, kantei, council, etc.) via the SourceAdapter abstraction
-2. **AI processing**: Groups speeches by topic, classifies tension type (questioning, response, follow-up, etc.), generates summaries at three reading levels
-3. **News enrichment**: Searches Bing News for related articles, extracts OGP images for visual previews
-4. **Static generation**: Outputs JSON files consumed by Next.js SSG
-5. **Deployment**: Auto-deploys to Vercel
+1. **Sliding-window fetch**: Each run re-fetches the last 30 days from every source. NDL publishes transcripts with a multi-day to multi-week lag, so a yesterday-only fetch silently misses retroactively-published meetings.
+2. **AI processing**:
+   - **Grouping** — sync call per meeting; clusters speeches into thematic threads.
+   - **Summarization** — Message Batches API per thread (50% cost discount, stackable with prompt caching for ~90% input savings on the cached prefix).
+   - **Outcome extraction** — sync call per meeting; reads procedural speeches for vote results / attached resolutions.
+3. **News enrichment**: Searches Bing News by topic, then a Claude Haiku ranker (`scripts/pipeline/news_ranker.py`) picks the most-relevant 3 articles from the candidate pool. Auxiliary information layer — see CLAUDE.md "Summary Layer Invariants" for the boundary.
+4. **Static generation**: `data/threads/*.json` and `data/members.json` are consumed by the Next.js SSG to produce static HTML pages.
+5. **Deployment**: Two Vercel projects pointing at the same repo — root (SSG frontend) and `apps/mcp` (dynamic MCP server).
+6. **Monitoring**: Daily batch commits include `(+N threads)` in the message; the workflow emits a CI warning when 7+ consecutive runs add 0 threads (catches fetcher regressions that the green checkmark alone wouldn't).
 
 ## Data Pipeline
 
 ```bash
-# 1. Fetch speeches from various sources
-python scripts/fetch_ndl.py --date-from 2025-03-14
-python scripts/fetch_kantei.py --date-from 2025-03-14
-python scripts/fetch_council.py --date-from 2025-12-24  # council meeting minutes (PDF)
+# 1. Fetch speeches across a sliding window (30 days catches retroactive NDL uploads)
+python scripts/fetch_ndl.py     --lookback-days 30
+python scripts/fetch_kantei.py  --lookback-days 30
+python scripts/fetch_council.py --lookback-days 30 --council kisei
+# (... repeat per council, see daily-batch.yml for the full list)
 
-# 2. Summarize with Claude API (requires ANTHROPIC_API_KEY in .env)
-python scripts/summarize.py --date 2025-03-14
+# 2. Summarize via Message Batches API (auto-resumes against existing data/threads/)
+#    Requires ANTHROPIC_API_KEY in .env.
+python scripts/summarize.py --date 2026-04-22 --batch
 
-# 3. Build and preview
+# 3. Enrich with news, filtered through Claude relevance ranker
+python scripts/enrich-news.py --date 2026-04-22 --rank-with-claude
+
+# 4. Generate sitemaps, feeds, and validation; build the SSG
+node scripts/validate-data.mjs --fix
+node scripts/generate-feeds.js
+node scripts/generate-sitemap.mjs
 npm run build && npx serve out
 ```
 
-See `.env.example` for configuration.
+See `.env.example` for configuration. The daily batch workflow at `.github/workflows/daily-batch.yml` runs all of these in sequence at 6:00 JST.
+
+## MCP Server
+
+OpenGIKAI exposes its dataset as a read-only [Model Context Protocol](https://modelcontextprotocol.io) server so Claude Desktop, Cline, or any MCP-capable agent can query Diet discussions directly.
+
+| Tool | Purpose |
+|------|---------|
+| `search_threads` | Find threads by keyword, date range, committee, or source |
+| `get_thread` | Fetch a full thread with 3-level summaries, original quotes, tension classifications, and outcomes |
+| `get_member` | Diet member profile |
+| `list_members` | Paginate members, filter by name/party |
+| `list_dates` | Index of dates with available threads |
+
+The server lives in `apps/mcp/` and is deployed as a second Vercel project from the same repository. OpenGIKAI does NOT pay for LLM inference — the MCP client (Claude Desktop, etc.) calls Claude with its own API key, and the server only returns JSON. See [`apps/mcp/README.md`](./apps/mcp/README.md) for the endpoint URL and Claude Desktop configuration snippet.
 
 ## Design Principles
 
-- **Political neutrality by design** — All speeches processed with identical algorithms. No editorial selection. Prompts are open-source.
-- **Source transparency** — Every summary links to the original NDL transcript
-- **AI transparency** — All AI-generated content is clearly labeled
-- **Accessibility** — Three reading levels make Diet proceedings approachable for everyone
+- **Political neutrality by design** — All speeches processed with identical algorithms. No editorial selection. Prompts are open-source. See "Summary Layer Invariants" in [`CLAUDE.md`](./CLAUDE.md) for the non-negotiable rules (stateless, deterministic, prompt-only) and the boundary between the summary layer and auxiliary layers (news enrichment, MCP server) where LLM/agent patterns are allowed.
+- **Source transparency** — Every summary links to the original NDL/kantei/council transcript.
+- **AI transparency** — All AI-generated content is clearly labeled. MCP responses include an `attribution` block making this explicit for downstream agents.
+- **Accessibility** — Three reading levels make Diet proceedings approachable for everyone.
 
 ## Data Source
 


### PR DESCRIPTION
## Summary
今セッション（PR #34 / #35 / #36 / #37）でパイプラインと配置が大きく変わったので、ユーザー向けドキュメントを最新化します。

### 変更内容
- **README.md / README.ja.md**:
  - Tech Stack: Next.js 15 → 16、単一 Vercel project → 2 projects、Message Batches API + prompt caching、MCP server 行を追加
  - Project Structure: \`apps/mcp/\`、\`scripts/pipeline/\`、 \`data/threads/\` を含む現状の構造を反映
  - How It Works: 30 日 sliding-window fetch、Batches API、Claude 関連度判定、2 つのデプロイターゲット
  - Data Pipeline コマンド例: \`--lookback-days 30\`、\`--batch\`、\`--rank-with-claude\` を反映
  - MCP server セクションを新設（tool 一覧、コスト構造、\`apps/mcp/README.md\` への誘導）
  - Design Principles に「Summary Layer Invariants」への参照を追加
- **CLAUDE.md**:
  - Tech Stack のパイプライン詳細を最新化
  - Development Commands に \`apps/mcp\` 系コマンドを追加
  - MCP server のデータ取り込みを「outputFileTracingRoot」から「prebuild copy」に訂正（実装と一致）

### あえて触らないもの
- **HANDOFF.md** — 当初の実装指示書として歴史的記録に。現在の実装とはズレているが意図的に残す
- **CONTRIBUTING.md / CONTRIBUTING.ja.md** — 仕様変更とは独立した貢献ガイドなので無関係
- **CODE_OF_CONDUCT.md** — 一般的内容

## Test plan
- [x] README に書かれた CLI 例が現スクリプトの引数と一致していること
- [x] CLAUDE.md の指示が当該 PR でマージ済みの実装と矛盾しないこと
- [ ] レビュー時に「初見の開発者が README だけ読んで全体像を掴めるか」をチェックしてもらう

🤖 Generated with [Claude Code](https://claude.com/claude-code)