### PR TITLE
fix(pipeline): cross-run resume for timed-out summary batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
           path: out/
           retention-days: 1
 
+  python-tests:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install anthropic python-dotenv pytest
+      - run: cd scripts && python -m pytest -q
+
   e2e:
     name: E2E Tests
     needs: build

--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: daily-batch
+  cancel-in-progress: false
+
 jobs:
   fetch-and-summarize:
     name: Fetch & Summarize
@@ -82,13 +86,28 @@ jobs:
           echo "Found raw data for dates: $DATES"
           echo "list=$DATES" >> "$GITHUB_OUTPUT"
 
+      # ----- Resume in-flight batches from prior runs FIRST -----
+      # Collects any committed sidecars (data/pending-batches/) within a shared
+      # budget. Exits non-zero only when a batch has failed too many times.
+      - name: Collect pending batches
+        id: collect
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/summarize.py --collect-pending --batch-budget 1800 --ci-commit
+          if ls data/pending-batches/*.json >/dev/null 2>&1; then
+            echo "has_pending=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pending=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ----- Summarize (auto-resume per date) -----
       # --batch routes the per-thread summary calls through the Message
       # Batches API for a 50% input/output token discount, stackable with
       # the prompt-caching prefix. Grouping and outcome extraction remain
       # synchronous (one small call per meeting; not worth batching).
       - name: Summarize new content with Claude API
-        if: steps.dates.outputs.list != ''
+        if: steps.dates.outputs.list != '' && steps.collect.outputs.has_pending != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DATES_LIST: ${{ steps.dates.outputs.list }}
@@ -96,8 +115,14 @@ jobs:
           set -e
           for d in $DATES_LIST; do
             echo "::group::Summarize $d"
-            python scripts/summarize.py --date "$d" --batch
+            python scripts/summarize.py --date "$d" --batch --batch-budget 1200 --ci-commit
             echo "::endgroup::"
+            # Once a date leaves a pending sidecar, stop submitting new batches
+            # so we never pile up multiple in-flight batches in one run.
+            if [ -f "data/pending-batches/$d.json" ]; then
+              echo "Batch for $d is pending — stopping further submits this run"
+              break
+            fi
           done
 
       # ----- Enrich threads with news articles (Bing News RSS) -----
@@ -161,7 +186,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           # public/sitemap*.xml covers sitemap.xml, sitemap-*.xml and sitemap_index.xml
           # — all variants emitted by generate-sitemap.mjs.
-          git add data/threads/ data/members.json data/status.json \
+          mkdir -p data/pending-batches
+          git add data/threads/ data/pending-batches/ data/members.json data/status.json \
             public/sitemap.xml public/sitemap-*.xml public/sitemap_index.xml \
             public/feed.xml
           if git diff --cached --quiet; then

--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -286,3 +286,36 @@ jobs:
             gh issue create --title "Daily Batch failed" \
               --label pipeline-failure --body "$BODY"
           fi
+
+  notify-stuck-batch:
+    name: Notify on stuck batch
+    needs: fetch-and-summarize
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Comment if any sidecar is older than 2 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          STUCK=$(python scripts/check_stuck_batches.py || true)
+          if [ -n "$STUCK" ]; then
+            gh label create pipeline-failure --color B60205 \
+              --description "Daily batch pipeline failure" 2>/dev/null || true
+            EXISTING=$(gh issue list --state open --label pipeline-failure \
+              --json number --jq '.[0].number' 2>/dev/null || true)
+            BODY=$(printf 'Stuck summary batch(es) detected (in-flight > 2 days):\n\n%s' "$STUCK")
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+            else
+              gh issue create --title "Stuck summary batch" \
+                --label pipeline-failure --body "$BODY"
+            fi
+          fi

--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -94,6 +94,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          set -e
           python scripts/summarize.py --collect-pending --batch-budget 1800 --ci-commit
           if ls data/pending-batches/*.json >/dev/null 2>&1; then
             echo "has_pending=true" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Sources (NDL, kantei, council)
 4. **Static generation**: `data/threads/*.json` and `data/members.json` are consumed by the Next.js SSG to produce static HTML pages.
 5. **Deployment**: Two Vercel projects pointing at the same repo — root (SSG frontend) and `apps/mcp` (dynamic MCP server).
 6. **Monitoring**: Daily batch commits include `(+N threads)` in the message; the workflow emits a CI warning when 7+ consecutive runs add 0 threads (catches fetcher regressions that the green checkmark alone wouldn't). A hard job failure (e.g. NDL API 403 from a datacenter IP, Anthropic credit exhaustion) opens or updates a `pipeline-failure` GitHub Issue so it surfaces without polling `gh run list`.
+   - **Batch resume**: A summary batch that exceeds the per-run poll budget is no longer cancelled. Its id + a grouping manifest (with per-thread `input_hash`) are persisted to a committed sidecar at `data/pending-batches/{date}.json` and resumed on the next run, which re-fetches raw, verifies the hash, and assembles without re-grouping. A batch stuck in-flight for >2 days, or one that fails 3 runs in a row, opens/updates the same `pipeline-failure` Issue.
 
 ## Data Pipeline
 

--- a/docs/superpowers/plans/2026-06-12-batch-resume.md
+++ b/docs/superpowers/plans/2026-06-12-batch-resume.md
@@ -1,0 +1,1565 @@
+# Cross-Run Batch Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist each summary batch's id + grouping manifest to a committed sidecar so a timed-out Anthropic batch resumes on the next daily run instead of being cancelled and lost.
+
+**Architecture:** A new pure module `scripts/pipeline/batch_state.py` owns the sidecar format (manifest + `attempts[]` + per-thread `input_hash`). `summarize.py` writes a sidecar at submit time (early-committed in CI), polls within a budget, and on a later run re-fetches raw + assembles from the manifest *without re-grouping* (custom_id is positional, so re-grouping risks silent corruption). The workflow gains a pre-collect step, a `concurrency` lock, break-on-pending, and a stuck-batch alert.
+
+**Tech Stack:** Python 3.12, Anthropic Message Batches API, pytest (new), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-batch-resume-design.md`
+
+---
+
+## File Structure
+
+- **Create** `scripts/pipeline/batch_state.py` — sidecar load/save/delete, manifest build, `input_hash`, `attempts[]` retry state machine, age/stuck helpers. Pure functions (no Anthropic client, no network), fully unit-testable.
+- **Create** `scripts/tests/__init__.py`, `scripts/tests/conftest.py` (fake Anthropic client + fixtures), `scripts/tests/test_batch_state.py`, `scripts/tests/test_resume.py`, `scripts/tests/test_poll.py`.
+- **Create** `scripts/tests/pytest.ini` (or rely on repo-root config) — minimal pytest config.
+- **Modify** `scripts/pipeline/summarizer.py` — `poll_summary_batch` returns the final batch object on ended OR budget-exhaustion; no cancel, no raise.
+- **Modify** `scripts/summarize.py` — manifest-aware submit, `assemble_from_manifest`, collect/resume path, `--collect-pending` CLI mode, `--batch-budget`, sidecar early-commit gate, HAS_PENDING via sidecar presence.
+- **Modify** `.github/workflows/daily-batch.yml` — `concurrency`, pre-collect step, break-on-pending submit loop, `data/pending-batches/` in `git add`, stuck-batch alert job with `issues: write`.
+- **Modify** `.github/workflows/ci.yml` — add a pytest step.
+- **Modify** `README.md` — monitoring section note.
+
+Sidecars live in `data/pending-batches/{date}.json` — **outside** `data/threads/`, because `validate-data.mjs:54-56` and `generate-sitemap.mjs:93-95` spread every `data/threads/*.json` as an array and would `TypeError` on an object.
+
+---
+
+## Task 1: pytest scaffolding + fake Anthropic client
+
+**Files:**
+- Create: `scripts/tests/__init__.py`
+- Create: `scripts/tests/conftest.py`
+- Create: `scripts/pytest.ini`
+
+- [ ] **Step 1: Create the package marker**
+
+Create `scripts/tests/__init__.py` (empty file).
+
+- [ ] **Step 2: Create pytest config**
+
+Create `scripts/pytest.ini`:
+
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+addopts = -q
+```
+
+- [ ] **Step 3: Create the fake Anthropic client and fixtures**
+
+Create `scripts/tests/conftest.py`:
+
+```python
+"""Shared pytest fixtures: a fake Anthropic Batches client.
+
+The fake mimics only the surface summarize.py uses:
+  client.messages.batches.create(requests=...)  -> object with .id / .processing_status
+  client.messages.batches.retrieve(batch_id)    -> object with .processing_status / .request_counts
+  client.messages.batches.results(batch_id)     -> iterable of result entries
+It is driven entirely by attributes set in each test (no network).
+"""
+
+import sys
+import os
+import types
+
+import pytest
+
+# Make `pipeline` importable exactly as summarize.py does.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class _Batch:
+    def __init__(self, batch_id, status, counts=None):
+        self.id = batch_id
+        self.processing_status = status
+        self.request_counts = counts or {}
+
+
+class _ResultEntry:
+    def __init__(self, custom_id, result_type, text=None):
+        self.custom_id = custom_id
+        message = types.SimpleNamespace(
+            content=[types.SimpleNamespace(text=text)] if text is not None else [],
+            usage=None,
+        )
+        self.result = types.SimpleNamespace(type=result_type, message=message)
+
+
+class FakeBatches:
+    def __init__(self):
+        # Tests set these to script behavior.
+        self.created_requests = []
+        self.next_id = "msgbatch_fake_0001"
+        self.statuses = {}          # batch_id -> processing_status to return
+        self.results_by_id = {}     # batch_id -> list[_ResultEntry]
+        self.cancelled = []
+
+    def create(self, requests):
+        self.created_requests.append(requests)
+        bid = self.next_id
+        self.statuses.setdefault(bid, "in_progress")
+        return _Batch(bid, self.statuses[bid])
+
+    def retrieve(self, batch_id):
+        return _Batch(batch_id, self.statuses.get(batch_id, "in_progress"),
+                      counts={"succeeded": len(self.results_by_id.get(batch_id, []))})
+
+    def results(self, batch_id):
+        return list(self.results_by_id.get(batch_id, []))
+
+    def cancel(self, batch_id):
+        self.cancelled.append(batch_id)
+
+
+class FakeClient:
+    def __init__(self):
+        self.messages = types.SimpleNamespace(batches=FakeBatches())
+
+
+@pytest.fixture
+def fake_client():
+    return FakeClient()
+```
+
+- [ ] **Step 4: Verify pytest discovers the (empty) suite**
+
+Run: `cd scripts && python -m pytest -q`
+Expected: `no tests ran` (exit 5) or `0 passed` — confirms config + import path work with no collection errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/tests/__init__.py scripts/tests/conftest.py scripts/pytest.ini
+git commit -m "test: add pytest scaffolding and fake Anthropic batches client"
+```
+
+---
+
+## Task 2: `batch_state.py` — canonical hash + sidecar new/load/save/delete
+
+**Files:**
+- Create: `scripts/pipeline/batch_state.py`
+- Test: `scripts/tests/test_batch_state.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/tests/test_batch_state.py`:
+
+```python
+import json
+import os
+
+from pipeline import batch_state as bs
+
+
+def test_canonical_json_is_order_insensitive():
+    a = bs.canonical_json({"b": 1, "a": [3, 2]})
+    b = bs.canonical_json({"a": [3, 2], "b": 1})
+    assert a == b
+
+
+def test_compute_input_hash_stable_and_prefixed():
+    params = {"model": "m", "max_tokens": 8192, "system": "S",
+              "messages": [{"role": "user", "content": "x"}]}
+    h1 = bs.compute_input_hash(params)
+    h2 = bs.compute_input_hash(dict(reversed(list(params.items()))))
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_compute_input_hash_changes_with_prompt():
+    p1 = {"system": "A", "messages": []}
+    p2 = {"system": "B", "messages": []}
+    assert bs.compute_input_hash(p1) != bs.compute_input_hash(p2)
+
+
+def test_new_sidecar_shape():
+    sc = bs.new_sidecar("2026-05-14", "claude-x")
+    assert sc["schema_version"] == 1
+    assert sc["date"] == "2026-05-14"
+    assert sc["model"] == "claude-x"
+    assert sc["retry_count"] == 0
+    assert sc["attempts"] == []
+    assert sc["meetings"] == []
+
+
+def test_save_load_delete_roundtrip(tmp_path):
+    path = str(tmp_path / "2026-05-14.json")
+    sc = bs.new_sidecar("2026-05-14", "claude-x")
+    bs.save_sidecar(path, sc)
+    assert os.path.exists(path)
+    loaded = bs.load_sidecar(path)
+    assert loaded == sc
+    bs.delete_sidecar(path)
+    assert not os.path.exists(path)
+    assert bs.load_sidecar(path) is None
+
+
+def test_sidecar_path_lives_outside_threads():
+    p = bs.sidecar_path("2026-05-14")
+    assert p == os.path.join("data", "pending-batches", "2026-05-14.json")
+    assert "threads" not in p
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts && python -m pytest tests/test_batch_state.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pipeline.batch_state'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `scripts/pipeline/batch_state.py`:
+
+```python
+"""Persistence for in-flight summary batches (cross-run resume).
+
+A sidecar at ``data/pending-batches/{date}.json`` records the batch id(s) and a
+grouping *manifest* for one date, so a timed-out batch can be collected on a
+later run without re-running the (non-deterministic-enough) grouping step.
+
+This module is pure: no Anthropic client, no network. It is the unit-testable
+core of the resume feature.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Optional
+
+PENDING_DIR = os.path.join("data", "pending-batches")
+SCHEMA_VERSION = 1
+
+# Terminal Anthropic batch statuses that are NOT a successful collection.
+TERMINAL_FAILURES = {"canceled", "expired"}
+
+
+def sidecar_path(date_str: str, pending_dir: str = PENDING_DIR) -> str:
+    return os.path.join(pending_dir, f"{date_str}.json")
+
+
+def canonical_json(obj) -> str:
+    """Deterministic JSON: sorted keys, compact separators, no ASCII escaping."""
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def compute_input_hash(params: dict) -> str:
+    """SHA256 of the canonical JSON of a batch request's ``params`` block.
+
+    Hashing the whole params (model, max_tokens, system, messages) ties a stored
+    result to the exact input + prompt that produced it, so a resume cannot
+    assemble a stale result against changed raw data or a changed prompt.
+    """
+    digest = hashlib.sha256(canonical_json(params).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def new_sidecar(date_str: str, model: str) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "date": date_str,
+        "model": model,
+        "retry_count": 0,
+        "attempts": [],
+        "meetings": [],
+    }
+
+
+def load_sidecar(path: str) -> Optional[dict]:
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_sidecar(path: str, sidecar: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(sidecar, f, ensure_ascii=False, indent=2)
+
+
+def delete_sidecar(path: str) -> None:
+    if os.path.exists(path):
+        os.remove(path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts && python -m pytest tests/test_batch_state.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pipeline/batch_state.py scripts/tests/test_batch_state.py
+git commit -m "feat(pipeline): add batch_state sidecar core (hash, new/load/save/delete)"
+```
+
+---
+
+## Task 3: `batch_state.py` — attempts[] + retry state machine + age
+
+**Files:**
+- Modify: `scripts/pipeline/batch_state.py`
+- Test: `scripts/tests/test_batch_state.py`
+
+- [ ] **Step 1: Write the failing tests (append to test file)**
+
+Append to `scripts/tests/test_batch_state.py`:
+
+```python
+def test_add_attempt_and_current_batch_id():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    assert bs.current_batch_id(sc) == "msgbatch_A"
+    assert sc["attempts"][-1]["terminal_status"] is None
+
+
+def test_record_terminal_increments_once_per_transition():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    # First observation of a failure transitions null -> expired: count.
+    assert bs.record_terminal(sc, "expired", "2026-06-11T23:20:00Z") is True
+    assert sc["retry_count"] == 1
+    # Re-observing the same terminal on the same attempt must NOT double count.
+    assert bs.record_terminal(sc, "expired", "2026-06-12T00:00:00Z") is False
+    assert sc["retry_count"] == 1
+
+
+def test_record_terminal_three_failures_across_attempts():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    for i in range(3):
+        bs.add_attempt(sc, f"msgbatch_{i}", "2026-06-11T21:50:00Z")
+        assert bs.record_terminal(sc, "expired", "2026-06-11T23:20:00Z") is True
+    assert sc["retry_count"] == 3
+    assert bs.should_hard_fail(sc) is True
+
+
+def test_should_hard_fail_below_threshold():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    bs.record_terminal(sc, "canceled", "2026-06-11T23:20:00Z")
+    assert bs.should_hard_fail(sc) is False
+
+
+def test_age_days_from_last_attempt():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-10T00:00:00Z")
+    assert bs.age_days(sc, "2026-06-12T00:00:00Z") == 2.0
+
+
+def test_is_stuck_uses_threshold():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-10T00:00:00Z")
+    assert bs.is_stuck(sc, "2026-06-12T01:00:00Z") is True   # >2d
+    assert bs.is_stuck(sc, "2026-06-11T00:00:00Z") is False  # 1d
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_batch_state.py -v -k "attempt or terminal or hard_fail or age or stuck"`
+Expected: FAIL with `AttributeError: module 'pipeline.batch_state' has no attribute 'add_attempt'`.
+
+- [ ] **Step 3: Implement (append to `batch_state.py`)**
+
+Append to `scripts/pipeline/batch_state.py`:
+
+```python
+from datetime import datetime, timezone
+
+HARD_FAIL_RETRIES = 3
+STUCK_AGE_DAYS = 2.0
+
+
+def add_attempt(sidecar: dict, batch_id: str, submitted_at: str) -> None:
+    sidecar["attempts"].append({
+        "batch_id": batch_id,
+        "submitted_at": submitted_at,
+        "terminal_status": None,
+        "terminal_at": None,
+    })
+
+
+def current_batch_id(sidecar: dict) -> Optional[str]:
+    if not sidecar["attempts"]:
+        return None
+    return sidecar["attempts"][-1]["batch_id"]
+
+
+def record_terminal(sidecar: dict, status: str, at: str) -> bool:
+    """Record a terminal failure on the current attempt.
+
+    Increments ``retry_count`` only on the null -> failure transition so the
+    same terminal state observed across multiple runs is not double counted.
+    Returns True if it newly transitioned (and counted), else False.
+    """
+    if not sidecar["attempts"]:
+        return False
+    attempt = sidecar["attempts"][-1]
+    if attempt["terminal_status"] is not None:
+        return False
+    attempt["terminal_status"] = status
+    attempt["terminal_at"] = at
+    sidecar["retry_count"] += 1
+    return True
+
+
+def should_hard_fail(sidecar: dict) -> bool:
+    return sidecar["retry_count"] >= HARD_FAIL_RETRIES
+
+
+def _parse_iso(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def age_days(sidecar: dict, now_iso: str) -> float:
+    submitted = sidecar["attempts"][-1]["submitted_at"]
+    delta = _parse_iso(now_iso) - _parse_iso(submitted)
+    return delta.total_seconds() / 86400.0
+
+
+def is_stuck(sidecar: dict, now_iso: str, threshold_days: float = STUCK_AGE_DAYS) -> bool:
+    return age_days(sidecar, now_iso) > threshold_days
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/test_batch_state.py -v`
+Expected: PASS (all batch_state tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pipeline/batch_state.py scripts/tests/test_batch_state.py
+git commit -m "feat(pipeline): add attempts[] retry state machine and stuck detection"
+```
+
+---
+
+## Task 4: `poll_summary_batch` returns status instead of cancel+raise
+
+**Files:**
+- Modify: `scripts/pipeline/summarizer.py:189-237`
+- Test: `scripts/tests/test_poll.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/tests/test_poll.py`:
+
+```python
+from pipeline.summarizer import poll_summary_batch
+
+
+def test_poll_returns_ended_batch(fake_client):
+    b = fake_client.messages.batches
+    b.statuses["msgbatch_X"] = "ended"
+    batch = poll_summary_batch(fake_client, "msgbatch_X",
+                               timeout_seconds=5, poll_interval_seconds=0)
+    assert batch.processing_status == "ended"
+    assert b.cancelled == []  # never cancels
+
+
+def test_poll_returns_pending_on_budget_exhaustion(fake_client):
+    b = fake_client.messages.batches
+    b.statuses["msgbatch_Y"] = "in_progress"
+    batch = poll_summary_batch(fake_client, "msgbatch_Y",
+                               timeout_seconds=0, poll_interval_seconds=0)
+    assert batch.processing_status == "in_progress"
+    assert b.cancelled == []  # no cancel — the batch is resumed next run
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_poll.py -v`
+Expected: FAIL — `test_poll_returns_pending_on_budget_exhaustion` raises `TimeoutError` (current behavior cancels + raises).
+
+- [ ] **Step 3: Replace the poll implementation**
+
+In `scripts/pipeline/summarizer.py`, replace the body of `poll_summary_batch` (lines 189-237) with:
+
+```python
+def poll_summary_batch(
+    client,
+    batch_id: str,
+    timeout_seconds: int = 1800,
+    poll_interval_seconds: int = 30,
+):
+    """Poll a batch until it ends or the budget elapses.
+
+    Returns the final batch object in BOTH cases. The caller inspects
+    ``batch.processing_status``: ``"ended"`` -> collect results; anything else
+    -> the batch is still in flight and will be resumed on a later run (its id
+    is persisted in a sidecar). We never cancel: cancelling would throw away a
+    batch that simply needs more time than this run's budget.
+    """
+    start = time.time()
+    last_logged = 0.0
+
+    while True:
+        batch = client.messages.batches.retrieve(batch_id)
+        elapsed = int(time.time() - start)
+
+        if batch.processing_status == "ended":
+            log.info(
+                "Batch %s ended after %ds (counts=%s)",
+                batch_id, elapsed, batch.request_counts,
+            )
+            return batch
+
+        if elapsed - last_logged >= 120:
+            log.info(
+                "Batch %s status=%s elapsed=%ds",
+                batch_id, batch.processing_status, elapsed,
+            )
+            last_logged = elapsed
+
+        if elapsed >= timeout_seconds:
+            log.info(
+                "Batch %s still %s after %ds budget — leaving for resume",
+                batch_id, batch.processing_status, elapsed,
+            )
+            return batch
+        time.sleep(poll_interval_seconds)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/test_poll.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pipeline/summarizer.py scripts/tests/test_poll.py
+git commit -m "refactor(pipeline): poll_summary_batch returns status instead of cancel+raise"
+```
+
+---
+
+## Task 5: Manifest builder in `summarize.py`
+
+Builds the sidecar `meetings[]` from the `prepared_meetings` that `run_batch_phase` already computes, capturing full `thread_info` + `input_hash` per thread.
+
+**Files:**
+- Modify: `scripts/summarize.py` (add `build_manifest_meetings`, import `batch_state` + `build_summary_request` already imported)
+- Test: `scripts/tests/test_resume.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/tests/test_resume.py`:
+
+```python
+from pipeline import batch_state as bs
+import summarize
+
+
+def _prep(meeting_id, threads):
+    """Mimic prepare_meeting_for_batch's output shape."""
+    return {
+        "meeting_id": meeting_id,
+        "outcome": {"result": None, "resolution": None, "status": "ongoing"},
+        "pending": [
+            {
+                "custom_id": t["custom_id"],
+                "meeting": {"house": "参議院", "meeting": "外交防衛委員会"},
+                "thread_info": t["thread_info"],
+                "thread_speeches": t["speeches"],
+            }
+            for t in threads
+        ],
+    }
+
+
+def test_build_manifest_meetings_captures_full_thread_info_and_hash():
+    threads = [{
+        "custom_id": "s_abc_00",
+        "thread_info": {"topic": "T", "topicTag": "tag", "topicColor": "#111",
+                        "summary": "s", "speechOrders": [1, 2]},
+        "speeches": [{"speechOrder": 1, "speech": "a"}, {"speechOrder": 2, "speech": "b"}],
+    }]
+    prepared = [_prep("M1", threads)]
+    manifest = summarize.build_manifest_meetings(prepared, model="claude-x")
+    assert len(manifest) == 1
+    m = manifest[0]
+    assert m["meeting_id"] == "M1"
+    t = m["threads"][0]
+    assert t["custom_id"] == "s_abc_00"
+    assert t["thread_idx"] == 0
+    assert t["thread_info"]["topicTag"] == "tag"   # FULL thread_info, not a subset
+    assert t["speechOrders"] == [1, 2]
+    assert t["input_hash"].startswith("sha256:")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py::test_build_manifest_meetings_captures_full_thread_info_and_hash -v`
+Expected: FAIL — `AttributeError: module 'summarize' has no attribute 'build_manifest_meetings'`.
+
+- [ ] **Step 3: Implement**
+
+In `scripts/summarize.py`, add the `batch_state` import near the other pipeline imports (after line 41):
+
+```python
+from pipeline import batch_state as bs
+```
+
+Add this function just below `make_batch_custom_id` (after line 346):
+
+```python
+def build_manifest_meetings(prepared_meetings: list, model: str) -> list:
+    """Build sidecar ``meetings[]`` from prepared meetings.
+
+    Captures the FULL thread_info (assemble_thread needs topicTag/topicColor/
+    summary/etc.) plus a per-thread input_hash so a resumed batch result can be
+    verified against re-fetched raw before being assembled.
+    """
+    meetings = []
+    for prep in prepared_meetings:
+        threads = []
+        for idx, p in enumerate(prep["pending"]):
+            request = build_summary_request(
+                p["meeting"], p["thread_info"], p["thread_speeches"],
+                p["custom_id"], model,
+            )
+            threads.append({
+                "custom_id": p["custom_id"],
+                "thread_idx": idx,
+                "thread_info": p["thread_info"],
+                "speechOrders": p["thread_info"].get("speechOrders", []),
+                "input_hash": bs.compute_input_hash(request["params"]),
+            })
+        meetings.append({
+            "meeting_id": prep["meeting_id"],
+            "outcome": prep["outcome"],
+            "threads": threads,
+        })
+    return meetings
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/summarize.py scripts/tests/test_resume.py
+git commit -m "feat(summarize): build sidecar manifest with full thread_info and input_hash"
+```
+
+---
+
+## Task 6: `assemble_from_manifest` — resume without re-grouping
+
+Given a sidecar, re-fetched meetings keyed by id, and batch results, assemble threads using the manifest only. Verify `input_hash` and require all custom_ids present.
+
+**Files:**
+- Modify: `scripts/summarize.py` (add `assemble_from_manifest`)
+- Test: `scripts/tests/test_resume.py`
+
+- [ ] **Step 1: Write the failing tests (append)**
+
+Append to `scripts/tests/test_resume.py`:
+
+```python
+def _sidecar_with_one_thread(input_hash):
+    return {
+        "schema_version": 1, "date": "2026-05-14", "model": "claude-x",
+        "retry_count": 0,
+        "attempts": [{"batch_id": "b1", "submitted_at": "2026-06-11T21:50:00Z",
+                      "terminal_status": None, "terminal_at": None}],
+        "meetings": [{
+            "meeting_id": "M1",
+            "outcome": {"result": None, "resolution": None, "status": "ongoing"},
+            "threads": [{
+                "custom_id": "s_abc_00", "thread_idx": 0,
+                "thread_info": {"topic": "T", "topicTag": "tag", "topicColor": "#111",
+                                "summary": "s", "speechOrders": [1]},
+                "speechOrders": [1], "input_hash": input_hash,
+            }],
+        }],
+    }
+
+
+def _meeting():
+    return {"meetingId": "M1", "house": "参議院", "meeting": "外交防衛委員会",
+            "date": "2026-05-14", "source": "ndl",
+            "speeches": [{"speechOrder": 1, "speech": "a", "speaker": "X",
+                          "speakerGroup": "G", "speakerPosition": "P",
+                          "speechURL": "http://x"}]}
+
+
+def _correct_hash():
+    m = _meeting()
+    ti = {"topic": "T", "topicTag": "tag", "topicColor": "#111", "summary": "s",
+          "speechOrders": [1]}
+    req = summarize.build_summary_request(m, ti, [m["speeches"][0]], "s_abc_00", "claude-x")
+    return bs.compute_input_hash(req["params"])
+
+
+def test_assemble_from_manifest_success():
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    results = {"s_abc_00": {"speeches": [{"speechOrder": 1, "tension": "確認",
+               "summaries": {"easy": "e", "teen": "t", "adult": "a"}}],
+               "commitments": []}}
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results, members={}, thread_counter=0,
+    )
+    assert ok is True
+    assert len(threads) == 1
+    assert threads[0]["topicTag"] == "tag"
+
+
+def test_assemble_fails_on_hash_mismatch():
+    sidecar = _sidecar_with_one_thread("sha256:deadbeef")  # wrong
+    results = {"s_abc_00": {"speeches": [{"speechOrder": 1}], "commitments": []}}
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results, members={}, thread_counter=0,
+    )
+    assert ok is False
+
+
+def test_assemble_fails_on_missing_result():
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results={}, members={}, thread_counter=0,
+    )
+    assert ok is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py -v -k assemble`
+Expected: FAIL — `AttributeError: ... 'assemble_from_manifest'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/summarize.py` (below `build_manifest_meetings`):
+
+```python
+def assemble_from_manifest(
+    sidecar: dict,
+    meetings_by_id: Dict[str, dict],
+    results: Dict[str, Optional[dict]],
+    members: Dict[str, dict],
+    thread_counter: int,
+) -> tuple:
+    """Assemble threads from a sidecar manifest + a completed batch's results.
+
+    Does NOT re-group. Verifies each thread's input_hash against re-fetched raw
+    and requires every custom_id to have a parsed result. Returns
+    ``(threads, ok)`` where ok is False if ANY thread fails verification or is
+    missing — in that case the caller keeps the sidecar for retry.
+    """
+    model = sidecar["model"]
+    date_str = sidecar["date"]
+    threads: list = []
+
+    for m in sidecar["meetings"]:
+        meeting_id = m["meeting_id"]
+        meeting = meetings_by_id.get(meeting_id)
+        if meeting is None:
+            log.error("Resume: raw missing for %s — cannot assemble", meeting_id)
+            return [], False
+        raw_lookup = build_speech_lookup(meeting.get("speeches", []))
+        outcome = m["outcome"]
+        manifest_threads = m["threads"]
+
+        for mt in manifest_threads:
+            custom_id = mt["custom_id"]
+            thread_info = mt["thread_info"]
+            orders = mt["speechOrders"]
+            thread_speeches = [raw_lookup[o] for o in orders if o in raw_lookup]
+            if len(thread_speeches) != len(orders):
+                log.error("Resume: speechOrder gap in %s/%s", meeting_id, custom_id)
+                return [], False
+
+            request = build_summary_request(
+                meeting, thread_info, thread_speeches, custom_id, model,
+            )
+            if bs.compute_input_hash(request["params"]) != mt["input_hash"]:
+                log.error("Resume: input_hash mismatch for %s — raw/prompt changed",
+                          custom_id)
+                return [], False
+
+            result = results.get(custom_id)
+            if not result:
+                log.error("Resume: missing result for %s", custom_id)
+                return [], False
+
+            thread_counter += 1
+            thread_id = make_thread_id(date_str, meeting_id, thread_counter)
+            thread = assemble_thread(
+                meeting, thread_info, result["speeches"], raw_lookup, members,
+                thread_id,
+            )
+            if not thread:
+                log.error("Resume: assemble_thread returned None for %s", custom_id)
+                return [], False
+
+            is_last = (mt is manifest_threads[-1])
+            thread["outcome"] = {
+                "result": outcome.get("result") if is_last else None,
+                "resolution": outcome.get("resolution") if is_last else None,
+                "commitments": result["commitments"] or [],
+                "status": outcome.get("status", "ongoing"),
+            }
+            threads.append(thread)
+
+    return threads, True
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py -v`
+Expected: PASS (all resume tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/summarize.py scripts/tests/test_resume.py
+git commit -m "feat(summarize): assemble_from_manifest resumes batches without re-grouping"
+```
+
+---
+
+## Task 7: Submit path writes sidecar + manifest (replace cancel-on-fail behaviour)
+
+Rework `run_batch_phase` so that after submit it persists a sidecar, polls within a budget, and on `ended` assembles + deletes the sidecar; on non-ended it leaves the sidecar (pending) and returns a pending flag. `prepare_meeting_for_batch` already returns everything needed.
+
+**Files:**
+- Modify: `scripts/summarize.py:394-492` (`run_batch_phase`) and its caller (lines 630-649)
+- Test: `scripts/tests/test_resume.py`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+Append to `scripts/tests/test_resume.py`:
+
+```python
+import os
+
+
+def test_run_batch_phase_persists_sidecar_when_pending(fake_client, tmp_path, monkeypatch):
+    # One meeting, grouping stubbed to a single thread; batch stays in_progress.
+    monkeypatch.setattr(summarize, "group_meeting",
+                        lambda c, m, model: [{"topic": "T", "topicTag": "tag",
+                                              "topicColor": "#111", "summary": "s",
+                                              "speechOrders": [1]}])
+    monkeypatch.setattr(summarize, "extract_meeting_outcome",
+                        lambda c, m, model: {"result": None, "resolution": None,
+                                             "status": "ongoing"})
+    pending_dir = str(tmp_path / "pending")
+    meeting = _meeting()
+    fake_client.messages.batches.statuses["msgbatch_fake_0001"] = "in_progress"
+
+    new_threads, _, completed, pending = summarize.run_batch_phase(
+        fake_client, [meeting], {"completed": [], "failed": []},
+        members={}, model="claude-x", date_str="2026-05-14", thread_counter=0,
+        batch_timeout_seconds=0, batch_poll_seconds=0,
+        pending_dir=pending_dir, ci_commit=False,
+    )
+    assert pending is True
+    assert new_threads == []
+    sc = bs.load_sidecar(os.path.join(pending_dir, "2026-05-14.json"))
+    assert sc is not None
+    assert bs.current_batch_id(sc) == "msgbatch_fake_0001"
+    assert sc["meetings"][0]["threads"][0]["input_hash"].startswith("sha256:")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py::test_run_batch_phase_persists_sidecar_when_pending -v`
+Expected: FAIL — `run_batch_phase()` got an unexpected keyword `pending_dir` / wrong return arity.
+
+- [ ] **Step 3: Implement — rewrite `run_batch_phase`**
+
+Replace `run_batch_phase` (lines 394-492) with the version below. It keeps Phase-1 prepare unchanged, then persists a sidecar before polling. New params: `pending_dir`, `ci_commit`. New return: a 4-tuple `(new_threads, thread_counter, completed_meeting_ids, pending)`.
+
+```python
+def run_batch_phase(
+    client,
+    meetings: List[dict],
+    progress: dict,
+    members: Dict[str, dict],
+    model: str,
+    date_str: str,
+    thread_counter: int,
+    batch_timeout_seconds: int = 1800,  # 30 min default budget
+    batch_poll_seconds: int = 30,
+    pending_dir: str = bs.PENDING_DIR,
+    ci_commit: bool = False,
+) -> tuple:
+    """Process meetings via Batches API. Persists a sidecar so a batch that
+    does not finish within the budget resumes on a later run.
+
+    Returns ``(new_threads, thread_counter, completed_meeting_ids, pending)``.
+    """
+    prepared_meetings: list[dict] = []
+    all_pending: list[dict] = []
+
+    for meeting in meetings:
+        meeting_id = meeting.get("meetingId", "unknown")
+        if meeting_id in progress["completed"]:
+            log.info("Skipping already completed: %s", meeting_id)
+            continue
+        log.info("Preparing for batch: %s", meeting_id)
+        try:
+            prep = prepare_meeting_for_batch(client, meeting, model)
+        except Exception as e:
+            log.error("Failed to prepare %s: %s", meeting_id, e)
+            progress["failed"].append(meeting_id)
+            continue
+        prepared_meetings.append(prep)
+        all_pending.extend(prep["pending"])
+
+    if not all_pending:
+        log.info("Batch phase: nothing to summarize")
+        return [], thread_counter, [], False
+
+    requests = [
+        build_summary_request(
+            p["meeting"], p["thread_info"], p["thread_speeches"],
+            p["custom_id"], model,
+        )
+        for p in all_pending
+    ]
+    log.info("Submitting %d summary requests via Batches API", len(requests))
+    batch_id = submit_summary_batch(client, requests)
+
+    # Persist the sidecar BEFORE the long poll so a kill mid-poll still resumes.
+    submitted_at = _utcnow_iso()
+    sidecar = bs.new_sidecar(date_str, model)
+    sidecar["meetings"] = build_manifest_meetings(prepared_meetings, model)
+    bs.add_attempt(sidecar, batch_id, submitted_at)
+    path = bs.sidecar_path(date_str, pending_dir)
+    bs.save_sidecar(path, sidecar)
+    if ci_commit:
+        _git_commit_sidecar(path, date_str)
+
+    batch = poll_summary_batch(
+        client, batch_id,
+        timeout_seconds=batch_timeout_seconds,
+        poll_interval_seconds=batch_poll_seconds,
+    )
+    if batch.processing_status != "ended":
+        log.info("Batch %s not ended within budget — sidecar kept for resume", batch_id)
+        return [], thread_counter, [], True
+
+    results = fetch_summary_results(client, batch_id)
+    meetings_by_id = {m.get("meetingId", "unknown"): m for m in meetings}
+    new_threads, ok = assemble_from_manifest(
+        sidecar, meetings_by_id, results, members, thread_counter,
+    )
+    if not ok:
+        log.error("Batch %s ended but assembly incomplete — keeping sidecar", batch_id)
+        return [], thread_counter, [], True
+
+    thread_counter += len(new_threads)
+    completed_meeting_ids = [m["meeting_id"] for m in sidecar["meetings"]]
+    bs.delete_sidecar(path)
+    return new_threads, thread_counter, completed_meeting_ids, False
+```
+
+Add two small helpers near the top of `summarize.py` (after the imports, e.g. below line 45):
+
+```python
+import subprocess
+from datetime import datetime, timezone
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_commit_sidecar(path: str, date_str: str) -> None:
+    """Commit + push just the sidecar (CI only) so the in-flight batch survives
+    a later kill or set -e failure before the run's final commit."""
+    try:
+        subprocess.run(["git", "add", path], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"chore(pipeline): persist pending batch {date_str}"],
+            check=True,
+        )
+        subprocess.run(["git", "push"], check=True)
+        log.info("Early-committed sidecar %s", path)
+    except subprocess.CalledProcessError as e:
+        log.warning("Early sidecar commit failed (%s) — relying on final commit", e)
+```
+
+- [ ] **Step 4: Update the caller in `run_pipeline`**
+
+Replace the `if batch:` block (lines 630-649) with:
+
+```python
+    pending = False
+    if batch:
+        new_threads, thread_counter, completed_ids, pending = run_batch_phase(
+            client, meetings, progress, members, model, date_str,
+            thread_counter,
+            batch_timeout_seconds=batch_timeout_seconds,
+            batch_poll_seconds=batch_poll_seconds,
+            pending_dir=pending_dir,
+            ci_commit=ci_commit,
+        )
+        all_threads.extend(new_threads)
+        for mid in completed_ids:
+            if mid not in progress["completed"]:
+                progress["completed"].append(mid)
+        save_progress(progress, progress_path)
+        log.info("Batch phase: +%d threads from %d meeting(s)%s",
+                 len(new_threads), len(completed_ids),
+                 " (batch pending — will resume)" if pending else "")
+```
+
+Add `pending_dir` and `ci_commit` to `run_pipeline`'s signature (line 525-538) with defaults `pending_dir: str = bs.PENDING_DIR` and `ci_commit: bool = False`, and thread them from `main()` (see Task 9). The early-resume threads-load block already handles appending.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/ -v`
+Expected: PASS (all tests, including the new sidecar-persist test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/summarize.py scripts/tests/test_resume.py
+git commit -m "feat(summarize): persist sidecar at submit, resume-or-keep on poll result"
+```
+
+---
+
+## Task 8: Collect/resume path + `--collect-pending` CLI
+
+A new path that scans `pending_dir`, retrieves each sidecar's current batch, and assembles ended ones (fetching that date's raw + writing into `{date}.json`). Hard-fails when any sidecar has `retry_count >= 3`.
+
+**Files:**
+- Modify: `scripts/summarize.py` (add `collect_pending_batches`, `_load_meetings_for_date`, CLI flag)
+- Test: `scripts/tests/test_resume.py`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+Append to `scripts/tests/test_resume.py`:
+
+```python
+def test_collect_assembles_ended_and_deletes_sidecar(fake_client, tmp_path, monkeypatch):
+    pending_dir = str(tmp_path / "pending")
+    threads_dir = str(tmp_path / "threads")
+    raw_dir = str(tmp_path / "raw")
+    os.makedirs(raw_dir)
+    # Write raw for the date so collect can re-fetch from disk.
+    import json as _json
+    with open(os.path.join(raw_dir, "ndl-2026-05-14.json"), "w", encoding="utf-8") as f:
+        _json.dump({"meetings": [_meeting()]}, f, ensure_ascii=False)
+    # Sidecar with a correct hash, batch now ended with a result.
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    bs.save_sidecar(os.path.join(pending_dir, "2026-05-14.json"), sidecar)
+    b = fake_client.messages.batches
+    b.statuses["b1"] = "ended"
+    from tests.conftest import _ResultEntry  # type: ignore
+    import json as J
+    b.results_by_id["b1"] = [_ResultEntry("s_abc_00", "succeeded",
+        text=J.dumps({"speeches": [{"speechOrder": 1, "tension": "確認",
+        "summaries": {"easy": "e", "teen": "t", "adult": "a"}}], "commitments": []}))]
+
+    hard_fail = summarize.collect_pending_batches(
+        fake_client, members={}, model="claude-x",
+        pending_dir=pending_dir, threads_dir=threads_dir, raw_dir=raw_dir,
+        budget_seconds=0, poll_seconds=0, ci_commit=False,
+    )
+    assert hard_fail is False
+    assert not os.path.exists(os.path.join(pending_dir, "2026-05-14.json"))
+    assert os.path.exists(os.path.join(threads_dir, "2026-05-14.json"))
+
+
+def test_collect_hard_fails_at_retry_threshold(fake_client, tmp_path):
+    pending_dir = str(tmp_path / "pending")
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    sidecar["retry_count"] = 3
+    bs.save_sidecar(os.path.join(pending_dir, "2026-05-14.json"), sidecar)
+    hard_fail = summarize.collect_pending_batches(
+        fake_client, members={}, model="claude-x",
+        pending_dir=pending_dir, threads_dir=str(tmp_path / "t"),
+        raw_dir=str(tmp_path / "r"),
+        budget_seconds=0, poll_seconds=0, ci_commit=False,
+    )
+    assert hard_fail is True
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts && python -m pytest tests/test_resume.py -v -k collect`
+Expected: FAIL — `AttributeError: ... 'collect_pending_batches'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/summarize.py`:
+
+```python
+def _load_meetings_for_date(date_str: str, raw_dir: str) -> Dict[str, dict]:
+    """Re-load all meetings for a date from raw files, keyed by meetingId.
+
+    Mirrors run_pipeline's candidate-file scan so resume sees the same raw.
+    """
+    import glob as _glob
+    candidates = [
+        os.path.join(raw_dir, f"ndl-{date_str}.json"),
+        os.path.join(raw_dir, f"kantei-{date_str}.json"),
+        os.path.join(raw_dir, f"council-{date_str}.json"),
+        *sorted(_glob.glob(os.path.join(raw_dir, f"council-*-{date_str}.json"))),
+        os.path.join(raw_dir, f"{date_str}.json"),
+    ]
+    by_id: Dict[str, dict] = {}
+    for c in candidates:
+        if os.path.exists(c):
+            with open(c, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for m in data.get("meetings", []):
+                by_id[m.get("meetingId", "unknown")] = m
+    return by_id
+
+
+def _append_threads_to_date_file(threads: list, threads_dir: str, date_str: str) -> None:
+    os.makedirs(threads_dir, exist_ok=True)
+    path = os.path.join(threads_dir, f"{date_str}.json")
+    existing = []
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    existing.extend(threads)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, ensure_ascii=False, indent=2)
+
+
+def collect_pending_batches(
+    client,
+    members: Dict[str, dict],
+    model: str,
+    pending_dir: str = bs.PENDING_DIR,
+    threads_dir: str = "data/threads",
+    raw_dir: str = "data/raw",
+    budget_seconds: int = 1800,
+    poll_seconds: int = 30,
+    ci_commit: bool = False,
+) -> bool:
+    """Resume all in-flight batches. Returns True if any sidecar hit the
+    hard-fail retry threshold (caller should exit non-zero)."""
+    import glob as _glob
+    hard_fail = False
+    paths = sorted(_glob.glob(os.path.join(pending_dir, "*.json")))
+    deadline = time.time() + budget_seconds
+
+    for path in paths:
+        sidecar = bs.load_sidecar(path)
+        if sidecar is None:
+            continue
+        if bs.should_hard_fail(sidecar):
+            log.error("Sidecar %s exceeded retry threshold (%d) — hard fail",
+                      path, sidecar["retry_count"])
+            hard_fail = True
+            continue
+
+        date_str = sidecar["date"]
+        batch_id = bs.current_batch_id(sidecar)
+        remaining = max(0, int(deadline - time.time()))
+        batch = poll_summary_batch(client, batch_id,
+                                   timeout_seconds=remaining, poll_interval_seconds=poll_seconds)
+
+        if batch.processing_status != "ended":
+            if batch.processing_status in bs.TERMINAL_FAILURES:
+                if bs.record_terminal(sidecar, batch.processing_status, _utcnow_iso()):
+                    bs.save_sidecar(path, sidecar)
+                    if ci_commit:
+                        _git_commit_sidecar(path, date_str)
+                log.warning("Batch %s %s — will re-submit next run", batch_id,
+                            batch.processing_status)
+            else:
+                log.info("Batch %s still %s — leaving for next run", batch_id,
+                         batch.processing_status)
+            continue
+
+        results = fetch_summary_results(client, batch_id)
+        meetings_by_id = _load_meetings_for_date(date_str, raw_dir)
+        if not meetings_by_id:
+            log.error("Resume: no raw for %s (outside window?) — keeping sidecar",
+                      date_str)
+            continue
+        threads, ok = assemble_from_manifest(
+            sidecar, meetings_by_id, results, members, thread_counter=0,
+        )
+        if not ok:
+            if bs.record_terminal(sidecar, "assemble_failed", _utcnow_iso()):
+                bs.save_sidecar(path, sidecar)
+            log.error("Resume: assembly incomplete for %s — keeping sidecar", date_str)
+            continue
+
+        _append_threads_to_date_file(threads, threads_dir, date_str)
+        bs.delete_sidecar(path)
+        log.info("Resume: collected %d threads for %s", len(threads), date_str)
+
+    return hard_fail
+```
+
+Note: `assemble_from_manifest` uses `thread_counter` only for id suffixing; collect passes 0 and `_append_threads_to_date_file` preserves existing threads. Thread-id collisions are avoided because `make_thread_id` hashes the meeting_id and the per-meeting index space is small; if a collision is a concern, seed `thread_counter` from the existing file length — out of scope here (YAGNI; ids include the meeting hash).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scripts && python -m pytest tests/ -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/summarize.py scripts/tests/test_resume.py
+git commit -m "feat(summarize): collect_pending_batches resumes/retries in-flight batches"
+```
+
+---
+
+## Task 9: Wire CLI flags + `run_pipeline` signature
+
+**Files:**
+- Modify: `scripts/summarize.py` (`run_pipeline` signature, `parse_args`, `main`)
+
+- [ ] **Step 1: Extend `run_pipeline` signature**
+
+In `run_pipeline` (line 525-538) add params: `pending_dir: str = bs.PENDING_DIR`, `ci_commit: bool = False`. (Defaults keep existing callers/tests working.)
+
+- [ ] **Step 2: Add CLI flags in `parse_args`** (after line 760)
+
+```python
+    parser.add_argument(
+        "--collect-pending", action="store_true",
+        help="Resume in-flight batches from data/pending-batches/ and exit. "
+             "Non-zero exit if a sidecar exceeds the retry threshold.",
+    )
+    parser.add_argument(
+        "--pending-dir", default="data/pending-batches",
+        help="Directory for in-flight batch sidecars",
+    )
+    parser.add_argument(
+        "--batch-budget", type=int, default=1800,
+        help="Per-run poll budget in seconds (default 1800 = 30min)",
+    )
+    parser.add_argument(
+        "--ci-commit", action="store_true",
+        help="Early-commit+push the sidecar after submit (CI only)",
+    )
+```
+
+Also change `--batch-timeout` default from `5400` to `1800` to match the new budget.
+
+- [ ] **Step 3: Branch in `main`** (replace the `run_pipeline(...)` call, line 773-786)
+
+```python
+    client_kwargs = {}
+    if args.collect_pending:
+        import anthropic as _anthropic
+        client = _anthropic.Anthropic()
+        members = load_members(args.members_path)
+        hard_fail = collect_pending_batches(
+            client, members, args.model,
+            pending_dir=args.pending_dir, threads_dir=args.output_dir,
+            raw_dir=args.raw_dir, budget_seconds=args.batch_budget,
+            poll_seconds=args.batch_poll, ci_commit=args.ci_commit,
+        )
+        save_members(members, args.members_path)
+        if hard_fail:
+            sys.exit(1)
+        return
+
+    run_pipeline(
+        date_str=args.date,
+        meeting_filter=args.meeting,
+        model=args.model,
+        raw_dir=args.raw_dir,
+        output_dir=args.output_dir,
+        members_path=args.members_path,
+        resume=args.resume,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+        batch=args.batch,
+        batch_timeout_seconds=args.batch_budget,
+        batch_poll_seconds=args.batch_poll,
+        pending_dir=args.pending_dir,
+        ci_commit=args.ci_commit,
+    )
+```
+
+- [ ] **Step 4: Run the full suite + a dry smoke**
+
+Run: `cd scripts && python -m pytest tests/ -v && python summarize.py --collect-pending --pending-dir /tmp/empty_pending`
+Expected: tests PASS; the collect smoke logs nothing to do and exits 0 (no sidecars).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/summarize.py
+git commit -m "feat(summarize): add --collect-pending/--batch-budget/--ci-commit CLI"
+```
+
+---
+
+## Task 10: Workflow — concurrency, pre-collect, break-on-pending, git add
+
+**Files:**
+- Modify: `.github/workflows/daily-batch.yml`
+
+- [ ] **Step 1: Add a concurrency lock** (after line 17, top-level `permissions:` block)
+
+```yaml
+concurrency:
+  group: daily-batch
+  cancel-in-progress: false
+```
+
+- [ ] **Step 2: Add a pre-collect step** (before "Summarize new content", after the "Detect dates" step ~line 84)
+
+```yaml
+      # ----- Resume in-flight batches from prior runs FIRST -----
+      # Collects any committed sidecars (data/pending-batches/) within a shared
+      # budget. Exits non-zero only when a batch has failed too many times.
+      - name: Collect pending batches
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/summarize.py --collect-pending --batch-budget 1800 --ci-commit
+          if ls data/pending-batches/*.json >/dev/null 2>&1; then
+            echo "has_pending=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pending=false" >> "$GITHUB_OUTPUT"
+          fi
+        id: collect
+```
+
+- [ ] **Step 3: Guard the submit loop with break-on-pending** (replace the Summarize step body, lines 90-101)
+
+```yaml
+      - name: Summarize new content with Claude API
+        if: steps.dates.outputs.list != '' && steps.collect.outputs.has_pending != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DATES_LIST: ${{ steps.dates.outputs.list }}
+        run: |
+          set -e
+          for d in $DATES_LIST; do
+            echo "::group::Summarize $d"
+            python scripts/summarize.py --date "$d" --batch --batch-budget 1200 --ci-commit
+            echo "::endgroup::"
+            # Once a date leaves a pending sidecar, stop submitting new batches
+            # so we never pile up multiple in-flight batches in one run.
+            if [ -f "data/pending-batches/$d.json" ]; then
+              echo "Batch for $d is pending — stopping further submits this run"
+              break
+            fi
+          done
+```
+
+- [ ] **Step 4: Add `data/pending-batches/` to the commit step** (line 164)
+
+Change the `git add` line to include the pending dir:
+
+```yaml
+          git add data/threads/ data/pending-batches/ data/members.json data/status.json \
+            public/sitemap.xml public/sitemap-*.xml public/sitemap_index.xml \
+            public/feed.xml
+```
+
+Add a guard just before it so `git add` does not fail when the dir is absent:
+
+```yaml
+          mkdir -p data/pending-batches
+```
+
+- [ ] **Step 5: Validate the workflow YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/daily-batch.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/daily-batch.yml
+git commit -m "ci(daily-batch): concurrency lock, pre-collect, break-on-pending, commit sidecars"
+```
+
+---
+
+## Task 11: Workflow — stuck-batch alert job (`issues: write`)
+
+A separate job (so it has `issues: write` independent of the `contents: write`-only main job) that, after the main job, checks committed sidecars older than 2 days and comments on Issue #41.
+
+**Files:**
+- Modify: `.github/workflows/daily-batch.yml`
+
+- [ ] **Step 1: Add the alert job** (after the `notify-on-failure` job)
+
+```yaml
+  notify-stuck-batch:
+    name: Notify on stuck batch
+    needs: fetch-and-summarize
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Comment if any sidecar is older than 2 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          STUCK=$(python scripts/check_stuck_batches.py || true)
+          if [ -n "$STUCK" ]; then
+            gh label create pipeline-failure --color B60205 \
+              --description "Daily batch pipeline failure" 2>/dev/null || true
+            EXISTING=$(gh issue list --state open --label pipeline-failure \
+              --json number --jq '.[0].number' 2>/dev/null || true)
+            BODY=$(printf 'Stuck summary batch(es) detected (in-flight > 2 days):\n\n%s' "$STUCK")
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+            else
+              gh issue create --title "Stuck summary batch" \
+                --label pipeline-failure --body "$BODY"
+            fi
+          fi
+```
+
+- [ ] **Step 2: Create the checker script**
+
+Create `scripts/check_stuck_batches.py`:
+
+```python
+#!/usr/bin/env python3
+"""Print a line per sidecar whose in-flight batch is older than the stuck
+threshold. Empty output means nothing is stuck. Used by daily-batch.yml."""
+
+import glob
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pipeline import batch_state as bs  # noqa: E402
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for path in sorted(glob.glob(os.path.join(bs.PENDING_DIR, "*.json"))):
+        sc = bs.load_sidecar(path)
+        if sc and sc.get("attempts") and bs.is_stuck(sc, now):
+            print(f"- {sc['date']}: {bs.current_batch_id(sc)} "
+                  f"(age {bs.age_days(sc, now):.1f}d, retries {sc['retry_count']})")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Smoke-test the checker**
+
+Run: `cd scripts && python check_stuck_batches.py`
+Expected: no output (no sidecars locally) and exit 0.
+
+- [ ] **Step 4: Validate YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/daily-batch.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/daily-batch.yml scripts/check_stuck_batches.py
+git commit -m "ci(daily-batch): alert on summary batches stuck in-flight over 2 days"
+```
+
+---
+
+## Task 12: CI — run pytest
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a pytest job/step**
+
+Add a job to `.github/workflows/ci.yml` (mirror the existing job style):
+
+```yaml
+  python-tests:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install anthropic python-dotenv pytest
+      - run: cd scripts && python -m pytest -q
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run pipeline pytest suite"
+```
+
+---
+
+## Task 13: Docs + memory update
+
+**Files:**
+- Modify: `README.md` (monitoring section)
+- Modify: `/home/feathach/.claude/projects/-home-feathach-dev-open-gikai/memory/project_daily_batch_failures.md`
+
+- [ ] **Step 1: Update README monitoring note**
+
+Find the monitoring/daily-batch section in `README.md` and add a short paragraph:
+
+> Summary batches that exceed the per-run poll budget are no longer cancelled.
+> Their id + grouping manifest is persisted to `data/pending-batches/{date}.json`
+> (committed) and resumed on the next run. A batch stuck in-flight for >2 days,
+> or one that fails 3 runs in a row, opens/updates the `pipeline-failure` issue.
+
+- [ ] **Step 2: Update the memory file**
+
+In `project_daily_batch_failures.md`, update bullet 4 to note the root fix landed: batch_id is now persisted via `data/pending-batches/` sidecars with `input_hash` verification and cross-run resume; `poll_summary_batch` no longer cancels; retry_count>=3 hard-fails; stuck>2d alerts via a dedicated `issues: write` job.
+
+- [ ] **Step 3: Final full-suite run**
+
+Run: `cd scripts && python -m pytest -q`
+Expected: PASS (all tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: note cross-run batch resume in monitoring section"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage:** §0 manifest (Task 5/6), §1 sidecar+input_hash+attempts (Task 2/3/5), §2 early commit + concurrency + hash verify (Task 7/10/6), §3 pre-collect + break-on-pending + budget (Task 8/9/10), §4 assemble + completeness + raw-missing (Task 6/8), §5 exit 0 + sidecar-only marker (Task 8/10), §6 retry 3→hard fail + stuck alert (Task 3/8/11), §7 pytest (Task 1-12), influence files (all). 
+- **Determinism / invariants:** resume never re-groups; it re-fetches raw and verifies `input_hash` before assembling, so a changed prompt or raw cannot corrupt output — it fails closed (keeps sidecar). No new state crosses into the summary content.
+- **Type consistency:** `run_batch_phase` now returns a 4-tuple `(threads, counter, completed_ids, pending)` — the only caller (Task 7 Step 4) is updated to match. `assemble_from_manifest` signature is identical in Task 6 and its callers (Task 7/8).
+```

--- a/docs/superpowers/specs/2026-06-12-batch-resume-design.md
+++ b/docs/superpowers/specs/2026-06-12-batch-resume-design.md
@@ -4,7 +4,7 @@
 - 対象: `scripts/summarize.py --batch` のサマリフェーズ
 - 関連 Issue: #41 (`pipeline-failure`)
 - 直前コミット: `58c0ed9 fix(pipeline): cancel timed-out summary batches and repair failure alerting`
-- レビュー: codex external review 2回反映済み（後述「レビュー反映」）
+- レビュー: codex external review 3回反映済み（後述「レビュー反映」）
 
 ## 背景と問題
 
@@ -30,10 +30,14 @@ daily-batch ワークフローが 2026-06-10・06-11 と2日連続で約1時間3
 - job permissions は `contents: write` のみ。`issues: write` は別 job `notify-on-failure` だけが持つ。
 - `data/raw/` は **リポジトリにコミットされていない**（追跡0件）。raw は run ごとに NDL 等から再 fetch される。
 - `concurrency:` 設定は無い（overlapping run があり得る）。
+- **`data/threads/*.json` の全 consumer は配列前提**:
+  `validate-data.mjs:54-56`（`threads.push(...data)`）と `generate-sitemap.mjs:93-95`（`for (const t of parsed)`）は
+  ディレクトリ内の全 `.json` を**配列として spread/反復**する。object JSON を置くと `TypeError` でビルドが壊れる。
 - 既存 `{date}.progress.json` は **run 内専用**（成功時 `summarize.py:713-714` で削除、git 管理外）。
   run 横断完了判定はコミット済み `{date}.json` から再導出（`summarize.py:587-604`）。
 
-→ batch_id を progress.json に置くと引き継げない。**意図的にコミットする専用 sidecar が必要。**
+→ batch_id を progress.json に置くと引き継げない。**意図的にコミットする専用 sidecar が必要**。
+かつ sidecar は **`data/threads/` の外**へ置く（上記 consumer を壊さないため）。
 
 ## 設計
 
@@ -53,20 +57,18 @@ temperature=0 でも完全な決定論は保証されず、モデル更新では
 
 ### 1. 永続化フォーマット（sidecar）
 
-日付ごとに `data/threads/{date}.pending-batch.json`:
+**配置**: `data/pending-batches/{date}.json`（`data/threads/` の外）。`data/pending-batches/` を
+`git add` 対象に追加する。これにより thread glob consumer（validate/generate）に一切触れない。
 
 ```json
 {
   "schema_version": 1,
+  "date": "2026-05-14",
   "model": "claude-...",
   "retry_count": 0,
   "attempts": [
-    {
-      "batch_id": "msgbatch_01HBjNG4...",
-      "submitted_at": "2026-06-11T21:50:15Z",
-      "terminal_status": null,
-      "terminal_at": null
-    }
+    { "batch_id": "msgbatch_01HBjNG4...", "submitted_at": "2026-06-11T21:50:15Z",
+      "terminal_status": null, "terminal_at": null }
   ],
   "meetings": [
     {
@@ -76,7 +78,7 @@ temperature=0 でも完全な決定論は保証されず、モデル更新では
         {
           "custom_id": "s_ab12cd34ef56_00",
           "thread_idx": 0,
-          "topic": "…",
+          "thread_info": { "...submit 時の grouper 出力を full で...": "" },
           "speechOrders": [12, 13, 14],
           "input_hash": "sha256:…"
         }
@@ -86,42 +88,50 @@ temperature=0 でも完全な決定論は保証されず、モデル更新では
 }
 ```
 
-- **`input_hash`（C2 対策）**: submit 時にそのスレッドの batch request 入力（thread_speeches の本文＋
-  プロンプト構築に使う確定要素）を正規化して取った SHA256。speech 本文そのものは持たない（sidecar を小さく保つ）。
-- **`attempts[]`（I5 対策）**: バッチ投入の履歴。再 submit 時は新しい attempt を push（古い batch_id は履歴に残す）。
-  現在の in-flight は `attempts[-1]`。`retry_count` は terminal 非成功で +1。
-- `data/threads/` は `git add data/threads/` 対象。回収完了時・恒久放棄時に sidecar を削除。
-- `summarize.py:682` の `.json` クリーンアップ glob が拾わないよう `.pending-batch.json` を明示除外。
+- **`thread_info` は full 永続化（I）**: `assemble_thread` は `topicTag` / `topicColor` / `summary` /
+  `contextDescription` / `legislationName` 等を参照する（`summarize.py:224,246`）。subset では再構築できないため、
+  submit 時点の `thread_info` を丸ごと保持する（speech 本文は含まない＝小さい）。
+- **`input_hash`（C2 対策）**: submit 時に `build_summary_request` が送る **params 全体**
+  （`model`, `max_tokens`, `SUMMARY_SYSTEM`, `SUMMARY_INSTRUCTIONS`, user input = thread_speeches 構成）を
+  **canonical JSON**（キーソート・空白正規化・固定エンコード）にして取る SHA256。生成関数と
+  canonicalization は1つに固定する（プロンプト変更後の誤 assemble、および key order/空白差による
+  誤 mismatch の両方を防ぐ）。
+- **`attempts[]`（I5 対策）**: バッチ投入履歴。再 submit 時に新 attempt を push（古い batch_id は履歴に残す）。
+  現在の in-flight は `attempts[-1]`。
 
 ### 2. 永続化境界（orphan 防護 / C2・C3）
 
 **問題**: submit 直後の sidecar 書き込みは workflow 末尾の commit & push まではリポジトリに残らない。
-途中 kill / `set -e` 後続失敗 / push 衝突で sidecar が残らないと、Anthropic 側にバッチは在るのに
-回収不能な **orphan（課金済み）** になる。さらに `data/raw/` は非コミットなので、resume 時の raw は
-別 fetch であり、submit 時スナップショットと一致する保証がない。
+途中 kill / `set -e` 後続失敗で sidecar が残らないと、Anthropic 側にバッチは在るのに回収不能な
+**orphan（課金済み）** になる。さらに `data/raw/` は非コミットなので resume 時の raw は別 fetch であり、
+submit 時スナップショットと一致する保証がない。
 
 **対策**:
 1. **early commit（CI 専用）**: sidecar を書いた直後、長い poll の前に sidecar だけを
-   `git add <sidecar> && git commit && git push`。ローカル実行では push しない（`CI` env / 明示フラグで gate）。
-   永続化境界を poll の前へ移す。
-2. **input_hash 照合（§4）**: resume 時に再 fetch した raw から thread_speeches を再構築し input_hash を再計算、
-   sidecar と一致した場合のみ assemble。raw 経路の silent corruption を閉じ、「raw 不変」前提への依存を消す。
-3. **concurrency ロック（C3）**: `daily-batch.yml` に `concurrency: { group: daily-batch, cancel-in-progress: false }`
-   を追加。さらに submit 直前に最新 sidecar を recheck（既に in-flight があれば submit しない）。
+   `git add data/pending-batches/<date>.json && git commit && git push`。ローカル実行では push しない
+   （`CI` env / 明示フラグで gate）。永続化境界を poll の前へ移す。
+   - 同一 run 内でそのバッチが完了して sidecar 削除まで進む場合、最終 commit は early commit を打ち消す
+     形になる。この履歴 churn は**許容**（運用上問題なし）。
+2. **input_hash 照合（§4）**: resume 時に再 fetch raw から thread_speeches を再構築し input_hash を再計算、
+   sidecar と一致した場合のみ assemble。raw 経路の silent corruption を閉じ「raw 不変」前提への依存を消す。
+3. **concurrency ロック（C3）**: `daily-batch.yml` に `concurrency: { group: daily-batch, cancel-in-progress: false }`。
+   さらに submit 直前に最新 sidecar を recheck（既に in-flight があれば submit しない）。
 
 ### 3. poll 予算と「pending 後 submit 停止」（C1）
 
-per-run のグローバル挙動を、**別プロセスの日付ループでも成立させる**ため workflow 側で制御する:
+別プロセスの日付ループでも per-run グローバル挙動を成立させるため workflow 側で制御する:
 
-1. **pre-collect ステップ（run 冒頭）**: `DATES_LIST` とは独立に `data/threads/*.pending-batch.json` を
-   走査し、既存 in-flight バッチを retrieve。ended は assemble、in_progress はグローバル予算内で待つ
-   （§4）。ここで予算を消費する。
-2. **submit ループ**: その後 `for d in $DATES_LIST` を回すが、ある日付の summarize.py が
-   **pending を返した（sidecar 新規作成）時点で shell ループを break**（以降の新規 submit をしない）。
-   summarize.py は「pending か否か」を終了コードまたは marker で workflow に伝える（exit 0 維持、
-   別経路で signal）。
-3. **グローバル予算**: 既定 **30分**（env 可変）。pre-collect と最初の submit-poll の合計をこの予算で bound。
-   30分 << 120分で、後続 enrich/validate/commit/push に余裕を残す。
+1. **pre-collect ステップ（run 冒頭・`DATES_LIST` 非依存）**: `data/pending-batches/*.json` を走査し、
+   既存 in-flight バッチを retrieve。ended は assemble、in_progress はグローバル予算内で待つ（§4）。
+   - **pending が1件でも残ったら workflow output `HAS_PENDING=true` を立て、後続 submit ループ全体を skip**
+     （pre-collect の pending も submit を止める。break-on-pending を「自日付」だけに限定しない／C1 補強）。
+   - **pending sidecar の日付を fetch 対象へ強制追加**（manual dispatch の短い lookback や 30日 window 外でも
+     raw を確保。raw を確保できない場合は §4 の degraded/hard-fail へ）。
+2. **submit ループ**: `HAS_PENDING` が偽のときのみ実行。ある日付の summarize.py が pending（sidecar 新規作成）を
+   返した時点で以降の新規 submit を止める。
+3. **pending signal は marker / workflow output に一本化**（exit 0 は維持。終了コードで pending を表さない）。
+4. **グローバル予算**: 既定 **30分**（env 可変）。pre-collect ＋最初の submit-poll の合計を bound。
+   30分 << 120分で後続 enrich/validate/commit/push に余裕を残す。
 
 健全なバッチ（3〜7分）は同一 run で回収され、通常日のデータ遅延はゼロ。
 
@@ -132,14 +142,14 @@ pre-collect で各 sidecar の `attempts[-1].batch_id` を retrieve():
 ```
 ended:
   各 meeting の raw を再 fetch → build_speech_lookup
+    - raw が無い（window 外）→ degraded: sidecar 保持＋詰まり通知。規定 run 数を超えたら hard fail（§6）
   各 thread: speechOrders で thread_speeches を引き、input_hash を再計算
-    - sidecar の input_hash と不一致、または speechOrder 欠落 → assemble 失敗（§6 へ）
+    - input_hash 不一致 / speechOrder 欠落 → assemble 失敗（§6 へ、sidecar 保持）
   fetch_summary_results(batch_id) を custom_id で対応付け
-    - manifest の全 custom_id が結果に揃っているか確認（I6）
-      欠落があれば meeting を completed にせず sidecar を保持（§6 へ）
-  全て揃い・全 hash 一致 → persisted topic/outcome と合わせて thread 組み立て
-  → threads 追記、meeting を completed、（全 meeting 完了で）sidecar 削除
-in_progress: グローバル予算内で待つ。完了すれば上と同様。予算切れは sidecar 据え置き・pending signal。
+    - manifest の全 custom_id が結果に揃っているか確認（I6）。欠落 → completed にせず sidecar 保持（§6）
+  全件揃い・全 hash 一致 → persisted full thread_info / outcome と合わせて thread 組み立て
+    → threads 追記、meeting を completed、（全 meeting 完了で）sidecar 削除
+in_progress: グローバル予算内で待つ。完了すれば上と同様。予算切れは sidecar 据え置き・HAS_PENDING。
 canceled/expired: §6（retry）。
 ```
 
@@ -148,37 +158,37 @@ canceled/expired: §6（retry）。
 
 ### 5. exit 0 と「何を書くか」
 
-- pending（予算切れで未完）でも **exit 0**（失敗でなく非同期待ち）。workflow へは別 signal で pending を伝える（§3-2）。
+- pending（予算切れで未完）でも **exit 0**（失敗でなく非同期待ち）。pending は workflow output/marker で伝える（§3-3）。
 - 完了 thread が無い日付は **空の `{date}.json` を作らない**。sidecar だけを残す。
   auto-resume（`summarize.py:587-604`）は「sidecar あり / threads ファイル無し」を許容するよう拡張。
-- クリーンアップで sidecar を削除しないこと。
 
 ### 6. retry / 詰まり検知 / エスカレーション
 
-- **assemble 失敗（input_hash 不一致 / custom_id 欠落 / 一部 request failed）**: meeting を completed にせず
-  sidecar を保持。該当 attempt を terminal 失敗として記録（`attempts[-1].terminal_status`）。
-- **terminal 非成功（expired/canceled/assemble失敗）**: `retry_count` +1。次の submit 機会で投げ直し、
-  新しい attempt を push。
-- **3回連続**（同一日付で terminal 非成功が 3 回）→ **hard fail（exit 非ゼロ・CI 赤）**。
-  `attempts[]` 履歴と `retry_count` を Issue #41 に明示し人間の介入を促す（緑のままのデータ停滞を防ぐ）。
+- **assemble 失敗（input_hash 不一致 / custom_id 欠落 / 一部 request failed / raw 欠落）**: meeting を completed に
+  せず sidecar を保持。
+- **terminal 非成功（expired/canceled/assemble 失敗）**: `attempts[-1].terminal_status` が **`null → 非成功` に
+  遷移した時だけ** `retry_count` を +1 し、その状態を commit してから次 attempt を作る
+  （複数 run で同一 terminal を再観測しても二重カウントしない／状態遷移を明示）。
+- **3回連続**（`retry_count >= 3`）→ **hard fail（exit 非ゼロ・CI 赤）**。`attempts[]` 履歴と `retry_count` を
+  Issue #41 に明示し人間の介入を促す（緑のままのデータ停滞を防ぐ）。
 - **詰まり検知（in_progress 長期化）**: `attempts[-1].submitted_at` が **2日超**なら、
-  `data/threads/*.pending-batch.json` を走査する軽量ステップが `gh issue comment`（Issue #41）で通知。
+  `data/pending-batches/*.json` を走査する軽量ステップが `gh issue comment`（Issue #41）で通知。
   - exit 0 化で `notify-on-failure`（`if: failure()`）は発火しないため別経路。
   - **この通知ステップ/ジョブには `issues: write` と `GH_TOKEN`・`GH_REPO` を明示**（I4。
-    fetch-and-summarize job は `contents: write` のみのため、専用 job 化するか job 権限を拡張する）。
+    fetch-and-summarize job は `contents: write` のみのため専用 job 化するか job 権限を拡張）。
 
 ### 7. テスト（pytest 基盤を新設）
 
 現状 Python テストは無し（`tests/unit/ministry.test.mjs` のみ）。最小 pytest を `scripts/tests/` に新設し、
 fake Anthropic client を用いる:
 
-- sidecar（attempts/manifest）の read/write/delete ラウンドトリップ
+- sidecar（attempts/manifest/full thread_info）の read/write/delete ラウンドトリップ
 - poll: 予算切れで raise/cancel せず pending を返す
 - resume assemble: sidecar + mocked `ended` → **再グルーピングなしで**同期パスと一致
-- **input_hash ガード（C2）**: raw を改変したケースで hash 不一致 → assemble せず sidecar 保持
-- **完全性（I6）**: 一部 custom_id 欠落 → meeting を completed にせず sidecar 保持
-- silent-corruption ガード: custom_id 対応のみで解決しグルーパーを呼ばない
-- retry: terminal 非成功 3 回で hard fail（exit 非ゼロ）
+- input_hash ガード（C2）: raw 改変で hash 不一致 → assemble せず sidecar 保持
+- canonicalization: 同一入力で key order/空白差があっても hash 安定、prompt 変更で hash 変化
+- 完全性（I6）: 一部 custom_id 欠落 → completed にせず sidecar 保持
+- retry 状態遷移: 同一 terminal の再観測で二重カウントしない／3回で hard fail
 - 詰まり検知: 経過2日超で通知経路が起動
 - `ci.yml` に pytest ステップ追加
 
@@ -186,18 +196,22 @@ fake Anthropic client を用いる:
 
 | ファイル | 変更内容 |
 | --- | --- |
-| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に。cancel は不要に |
-| `scripts/summarize.py` | sidecar(attempts/manifest+input_hash) load/save/delete、early commit(CI gate)、resume assemble（再グルーピングなし・hash照合・完全性チェック）、pending signal、retry/hard-fail、クリーンアップ除外、auto-resume 拡張 |
-| `.github/workflows/daily-batch.yml` | `concurrency:` 追加、pre-collect ステップ、submit ループの break-on-pending、early commit 連携、詰まり検知ステップ（`issues: write` 付き）、グローバル予算 env |
+| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に。cancel 不要に |
+| `scripts/summarize.py` | sidecar(attempts/manifest+full thread_info+input_hash) load/save/delete、early commit(CI gate)、resume assemble（再グルーピングなし・hash 照合・完全性チェック・raw 欠落 degraded）、HAS_PENDING signal、retry 状態遷移/hard-fail、auto-resume 拡張 |
+| `.github/workflows/daily-batch.yml` | `concurrency:` 追加、pre-collect ステップ（HAS_PENDING output・pending 日付の fetch 強制追加）、submit ループの skip/break-on-pending、early commit 連携、`data/pending-batches/` の git add、詰まり検知ステップ（`issues: write` 付き）、グローバル予算 env |
 | `scripts/tests/`（新規） | pytest + fake client |
 | `.github/workflows/ci.yml` | pytest ステップ追加 |
 | `README` 監視節 / メモリ `project_daily_batch_failures` | 根治済みに更新 |
 
+備考: sidecar を `data/pending-batches/` に置くため、`validate-data.mjs` / `generate-sitemap.mjs` /
+`summarize.py:682` の thread glob には**変更不要**（衝突を構造的に回避）。
+
 ## エラーハンドリング / エッジケース
 
-- **GHA が 120分 kill / set -e 後続失敗**: sidecar は early commit 済みのため永続。次 run が resume。
-- **raw が submit 時から変化**: input_hash 不一致で assemble せず保持（silent corruption を遮断、§6）。
-- **ended batch の一部欠落**: 全 custom_id 揃いを completion 条件にし、欠落は保持（I6/§6）。
+- **GHA 120分 kill / set -e 後続失敗**: sidecar は early commit 済みのため永続。次 run が resume。
+- **raw が submit 時から変化**: input_hash 不一致で assemble せず保持（silent corruption を遮断）。
+- **pending 日付が lookback window 外**: fetch 強制追加で raw 確保。確保不能なら degraded（保持＋通知）→規定超で hard fail。
+- **ended batch の一部欠落**: 全 custom_id 揃いを completion 条件にし欠落は保持（I6）。
 - **overlapping run**: `concurrency` ロック＋submit 直前 recheck で重複 submit を防止（C3）。
 - **expired/canceled の継続**: retry_count 3 回で hard fail（無限ループ/二重課金を遮断）。
 - **夜間に完了**: resume run が `ended` を即検出 → 待機なしで assemble。
@@ -206,28 +220,28 @@ fake Anthropic client を用いる:
 
 - 1日付で複数 in-flight バッチを並走させること。
 - 同期（非バッチ）フォールバック。
-- speech 本文を含むフル文脈の永続化（manifest＋input_hash で代替）。
+- speech 本文を含むフル文脈の永続化（manifest（thread_info）＋input_hash で代替）。
 - `batches.list()` による orphan リコンシリエーション（early commit + concurrency + グローバル予算で窓を
   ほぼゼロにする方針。将来必要になれば追加）。
 
 ## レビュー反映
 
-### 1回目（codex, 2026-06-12）
-- Critical: custom_id 位置依存 silent corruption → §0 マニフェスト永続化へ変更。
-- Critical: sidecar 永続化境界 → §2 early commit 導入。
-- Important: per-date poll 加算 → グローバル予算化。
-- Important: expired 再 submit の二重課金/無限ループ → §6 retry 3 回 hard fail。
-- Question: raw 安定性 / batch_pending 出力 → 明文化。
+### 1回目（codex）
+- Critical: custom_id 位置依存 silent corruption → §0 マニフェスト永続化。
+- Critical: sidecar 永続化境界 → §2 early commit。
+- Important: per-date poll 加算 → グローバル予算化。 / expired 再 submit 無限ループ → §6 retry 3 回 hard fail。
 
-### 2回目（codex, 2026-06-12）
-- **Critical C1**: 別プロセス日付ループでグローバル予算/submit 停止が不成立 → §3 で workflow pre-collect ＋
-  break-on-pending ＋グローバル予算に変更。
-- **Critical C2**: sidecar/raw 非原子（raw 非コミット）→ raw 経路の silent corruption → §1 `input_hash`＋
-  §4 照合で遮断。
-- **Critical C3**: concurrency ロック無し → 重複 submit/orphan → §2 `concurrency:`＋submit 直前 recheck。
-- **Important I4**: 詰まり通知 step の `issues: write` 不足 → §6 で権限明示/専用 job 化。
-- **Important I5**: retry schema 不足 → §1 `attempts[]` 履歴化。
-- **Important I6**: ended batch 一部欠落で thread 永久消失 → §4 全 custom_id 揃いを completion 条件に。
-- **Important I7**: raw mismatch で completed 化され再取得されない → §6 で assemble 失敗＝保持/retry。
-- **Question**: early commit のローカル push → §2 CI 専用 gate。sidecar 走査位置 → §3 pre-collect で
-  `DATES_LIST` 非依存に全 sidecar を走査。
+### 2回目（codex）
+- C1 別プロセス予算不成立 → §3 pre-collect＋break-on-pending＋グローバル予算。
+- C2 sidecar/raw 非原子 → §1 `input_hash`＋§4 照合。
+- C3 concurrency 無し → §2 `concurrency:`＋recheck。
+- I4 通知権限 / I5 attempts[] / I6 完全性 / I7 mismatch 保持 → 反映。
+
+### 3回目（codex）
+- **Critical**: sidecar が `data/threads/*.json` glob と衝突しビルド破壊 → §1 で `data/pending-batches/` へ移設。
+- **Critical**: pre-collect pending が submit を止めない → §3 で `HAS_PENDING` output によるループ skip。
+- **Important**: input_hash 正規化が曖昧 → §1 で full request params の canonical JSON に固定。
+- **Important**: manifest が thread_info subset で assemble 不能 → §1 で full thread_info を永続化。
+- **Important**: pending 日付が window 外で raw 欠落 → §3/§4 で fetch 強制追加＋degraded/hard-fail。
+- **Important**: retry_count 二重カウント → §6 で `null→非成功` 遷移時のみ加算する状態機械に明示。
+- **Question**: early commit の revert churn 許容 / pending signal は marker 一本化 → §2・§3 に明記。

--- a/docs/superpowers/specs/2026-06-12-batch-resume-design.md
+++ b/docs/superpowers/specs/2026-06-12-batch-resume-design.md
@@ -4,6 +4,7 @@
 - 対象: `scripts/summarize.py --batch` のサマリフェーズ
 - 関連 Issue: #41 (`pipeline-failure`)
 - 直前コミット: `58c0ed9 fix(pipeline): cancel timed-out summary batches and repair failure alerting`
+- レビュー: codex external review 反映済み（後述「レビュー反映」）
 
 ## 背景と問題
 
@@ -22,13 +23,13 @@ daily-batch ワークフローが 2026-06-10・06-11 と2日連続で約1時間3
 submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を submit → …
 ```
 
-混雑が続く限りデータが一切前進しない。これは構造的な弱点であり、根治は
-**batch_id の永続化による run 横断 resume**（メモ `project_daily_batch_failures` が既に指摘）。
+混雑が続く限りデータが一切前進しない。根治は **batch_id の永続化による run 横断 resume**。
 
 ## 不変条件（プロジェクト制約）
 
 - サマリ層は **stateless / deterministic / prompt-only**（CLAUDE.md「Summary Layer Invariants」）。
-  グルーピングと outcome 抽出は temperature=0 で決定論的。本設計はこの決定論性を活用する。
+  本設計は run 横断状態を sidecar に持つが、それは「未完バッチの回収先」を指すポインタ＋
+  「submit 時に確定した入力の写し」であり、サマリ**内容**を run 間で変化させない（同一入力→同一出力を保つ）。
 - GitHub Actions runner は使い捨て。run 横断で状態を渡すには **リポジトリへ commit & push** する必要がある。
 - daily-batch.yml は `set -e` のシェルループで日付ごとに `summarize.py --date $d --batch` を呼ぶ。
   非ゼロ終了でループ全体が失敗する。GHA `timeout-minutes: 120`。
@@ -36,7 +37,6 @@ submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を 
 ## 既存の永続化メカニズム（重要な区別）
 
 - `{date}.progress.json`: **run 内専用**。成功時に `summarize.py:713-714` で `os.remove` され、git 管理外。
-  プロセスクラッシュ/リトライ時の run 内 resumability 用。
 - **run 横断の状態**: コミット済みの `{date}.json`（threads ファイル）。
   既に表現されている meeting＝完了、として `summarize.py:587-604` の auto-resume が再導出する。
 
@@ -45,6 +45,22 @@ submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を 
 
 ## 設計
 
+### 0. なぜ「再グルーピング」ではなくマニフェスト永続化か（最重要）
+
+`make_batch_custom_id(meeting_id, idx)`（`summarize.py:338-346`）= `s_{sha256(meeting_id)[:12]}_{idx:02d}`。
+custom_id は **meeting_id とスレッド位置インデックスのみ**で、スレッド内容・speechOrders・topic を含まない。
+
+したがって resume 時に「再グルーピングして custom_id を再構築」する案は危険:
+グルーピング結果が1つでもズレると、custom_id は**位置ベースで常にマッチする**ため
+`results.get(custom_id)` は成功し、**古いサマリ結果を新しい thread_info に貼り付ける
+silent data corruption** になる（skip されない）。temperature=0 でも完全な決定論は保証されず、
+モデル更新では確実に破綻する。これはサマリ層の中立性・透明性保証を破る。
+
+**解決**: submit 時点で確定したグルーピング・マニフェストを sidecar に永続化し、
+resume 時は**再グルーピングせず**マニフェストどおりに assemble する。
+これは ①決定論依存を完全排除 ②resume 時のグルーパー/outcome LLM 呼び出し（コスト/時間）を省略
+③speech 本文は持たず sidecar を小さく保つ、を同時に満たす。
+
 ### 1. 永続化フォーマット（sidecar）
 
 日付ごとに `data/threads/{date}.pending-batch.json`:
@@ -52,99 +68,146 @@ submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を 
 ```json
 {
   "batch_id": "msgbatch_01HBjNG4...",
-  "meeting_ids": ["参議院_外交防衛委員会_2026-05-14_第8号", "..."],
   "model": "claude-...",
-  "submitted_at": "2026-06-11T21:50:15Z"
+  "submitted_at": "2026-06-11T21:50:15Z",
+  "retry_count": 0,
+  "last_terminal_status": null,
+  "meetings": [
+    {
+      "meeting_id": "参議院_外交防衛委員会_2026-05-14_第8号",
+      "outcome": { "result": null, "resolution": null, "status": "ongoing" },
+      "threads": [
+        { "custom_id": "s_ab12cd34ef56_00", "thread_idx": 0, "topic": "…", "speechOrders": [12, 13, 14] }
+      ]
+    }
+  ]
 }
 ```
 
+- speech 本文は持たない。`speechOrders` は raw_lookup への int 参照。resume 時に
+  raw data（コミット済みで不変）から `build_speech_lookup` を再構築して thread_speeches を引く。
 - `submit_summary_batch` の **直後**（ポーリング前）に書き込む。
-- `data/threads/` は既に `git add data/threads/` 対象なので自動でコミット & push される。
-- 結果の回収・assemble 完了時、または恒久放棄（expired/canceled）時に削除する。
+- `data/threads/` は `git add data/threads/` 対象。回収完了時・恒久放棄時に削除する。
 - `summarize.py:682` の `.json` クリーンアップ glob が拾わないよう、`.progress.json` と同様に
   `.pending-batch.json` を明示除外する。
 
-### 2. `poll_summary_batch` の挙動変更（`scripts/pipeline/summarizer.py`）
+### 2. 永続化境界（orphan 防護）
 
-- 現状: タイムアウト時に `client.messages.batches.cancel` + `raise TimeoutError`。
-- 変更後: タイムアウト時は **raise も cancel もせず**、終了状態を返す
-  （例: 戻り値で `ended` 完了か、予算切れの `pending` かを呼び出し側が判別できるようにする）。
-- `cancel` は恒久放棄（`expired` 等）時のみ。
-- `58c0ed9` の cancel を巻き戻すが正当: resume で結果を実際に使うため「無駄課金」懸念は消える。
+**問題**: submit 直後の sidecar 書き込みは、workflow 末尾の commit & push に到達して初めて
+リポジトリに残る。途中で kill / `set -e` の後続失敗 / push 衝突が起きると、Anthropic 側に
+バッチは在るが sidecar が残らず **orphan（課金済み・回収不能）** になる。
+「poll 予算が短いから commit に到達する」だけでは保証にならない。
 
-### 3. poll 予算（per-run）
+**対策**:
+1. **early commit**: sidecar を書いた直後、**長い poll に入る前に** sidecar だけを対象に
+   `git add <sidecar> && git commit && git push` を実行する（永続化境界を poll の前に移す）。
+   - 実装機構は writing-plans で確定。候補: (a) summarize.py が submit 後に targeted git push、
+     (b) workflow を「submit パス → sidecar commit → poll/collect パス」に分割。
+     最小変更は (a)。push 競合時は fast-forward リトライ。
+2. **グローバル poll 予算**: 後述（§3）。poll を per-date 加算ではなく per-run 全体で bound し、
+   120分上限到達前に確実に collect/commit ステップへ戻れるようにする。
 
-- デフォルト **20分**（1200s）。env で可変（既存の `batch_timeout_seconds` 系パラメータを流用/改名）。
+これにより orphan 窓はほぼゼロ。万一 early commit 前に kill されても、再 submit は次 window で
+冪等に行われる（同一 window の meeting が再取得されるため）。
+
+### 3. poll 予算（per-run グローバル）
+
+- **per-run 全体**で1つの予算。デフォルト **30分**（env 可変）。per-date 加算にしない。
 - 健全なバッチは 3〜7分で完了 → 従来通り **同一 run で回収**（通常日のデータ遅延ゼロ）。
-- 混雑時は 20分で exit 0 → 翌 run で resume。
-- 複数日付が未処理でも 3日付 × 20分 = 60分 < GHA 120分上限。commit/push ステップに必ず到達する。
+- 予算を使い切ったら、未完バッチの sidecar を据え置き **exit 0** で抜ける（翌 run で resume）。
+- pending が1件でも発生したら、その run ではそれ以上の**新規 submit を行わない**
+  （複数 in-flight の積み増しを防ぎ、予算と orphan 窓を抑える）。
+- 30分 << GHA 120分。fetch/enrich/validate/commit/push に十分な余裕を残す。
 
-### 4. resume フロー（`run_batch_phase` 冒頭に追加）
+### 4. resume フロー
+
+run 開始時、コミット済み sidecar を走査する。日付ごとに:
 
 ```
-sidecar を load。存在すれば:
-  retrieve(batch_id):
-    ended            → meeting_ids を再 prepare（決定論で同一 custom_id を再構築）
-                       → fetch_summary_results → assemble → threads 追記
-                       → meetings を completed に → sidecar 削除
-                       → その後、新規 meeting があれば通常の prepare + submit へ
-    in_progress      → poll 予算まで待つ。完了すれば上と同様に assemble。
-                       未完なら sidecar 据え置き・batch_pending=True で返す（同日付の新規 submit はしない）
-    canceled/expired → warning, sidecar 削除（放棄。次回 window fetch で再取得・再 submit）
+sidecar.batch_id を retrieve():
+  ended            → マニフェストどおり assemble:
+                       各 meeting の raw data を再取得 → build_speech_lookup
+                       → 各 thread の speechOrders で thread_speeches を引く
+                       → fetch_summary_results(batch_id) の結果を custom_id で対応付け
+                       → persisted topic / outcome と合わせて thread 組み立て
+                       → threads 追記、meeting を completed に、sidecar 削除
+  in_progress      → グローバル poll 予算内で待つ。完了すれば上と同様に assemble。
+                       予算切れなら sidecar 据え置き、batch_pending=True を立てる
+  canceled/expired → retry 処理（§6）
 ```
 
-- 不変条件: **1日付につき同時に in-flight バッチは1つ**。in-flight 中は同日付の新規 submit をしない。
+- assemble は**再グルーピングを行わない**（§0）。custom_id は sidecar の対応表のみで解決する。
+- 不変条件: **1日付につき同時に in-flight バッチは1つ**。
 
-### 5. exit 0 のシグナリング（`scripts/summarize.py`）
+### 5. exit 0 と「何を書くか」
 
-- `run_batch_phase` が `batch_pending=True` を返したら、main は出力を書き、sidecar を残し **exit 0**。
+- `run_batch_phase` が `batch_pending=True` を返したら、main は **exit 0**（pending は失敗でなく非同期待ち）。
+- pending のみで完了 thread が無い日付は、**空の `{date}.json` を作らない**。sidecar だけを残す。
+  auto-resume（`summarize.py:587-604`）は「sidecar あり / threads ファイル無し」を許容するよう拡張する。
 - `os.remove(progress_path)` 等のクリーンアップで sidecar を削除しないこと。
-- pending 状態は「失敗」ではなく「正常な非同期待ち」として扱う（CI 緑）。
 
-### 6. 詰まり検知アラート
+### 6. retry / 詰まり検知 / エスカレーション
 
-- sidecar の `submitted_at` が **2日以上前**（daily run 2回を越えて未完）なら「本当に詰まった」と判断。
-- 実装: daily-batch.yml に軽量ステップを追加し、`data/threads/*.pending-batch.json` の経過日数を
-  スキャン → 2日超なら `gh issue comment`（既存 Issue #41 / `pipeline-failure` ラベル）で
-  batch_id と経過を通知。
-- 既存 `notify-on-failure`（`if: failure()`）は exit 0 化のため発火しなくなるので、この別経路が必要。
-  `GH_REPO: ${{ github.repository }}` 設定を流用する。
+- **terminal 非成功（expired/canceled）**: 該当バッチを放棄して sidecar の `retry_count` を +1、
+  `last_terminal_status` を記録し、同 window の meeting を次の submit 機会で投げ直す。
+- **3回連続**（同一日付で expired/canceled が 3 回）→ **hard fail（exit 非ゼロ・CI 赤）**。
+  Issue #41 に batch 履歴と retry 回数を明示し、人間の介入を促す。緑のままデータ停滞を防ぐ。
+- **詰まり検知（in_progress が長期化）**: sidecar の `submitted_at` が **2日超**なら、
+  daily-batch.yml の軽量ステップが `data/threads/*.pending-batch.json` を走査して
+  `gh issue comment`（Issue #41 / `pipeline-failure`）で通知。
+  既存 `notify-on-failure`（`if: failure()`）は exit 0 化で発火しなくなるため、この別経路が必要。
+  `GH_REPO: ${{ github.repository }}` を流用。
 
 ### 7. テスト（pytest 基盤を新設）
 
 現状 Python テストは無し（`tests/unit/ministry.test.mjs` のみ）。最小 pytest を `scripts/tests/` に新設し、
 fake Anthropic client を用いる:
 
-- sidecar の read/write/delete ラウンドトリップ
-- poll: タイムアウトで raise/cancel せず pending を返す
-- 決定論: 同一 meeting の再 prepare が同一 custom_id を生む
-- resume: sidecar + mocked `ended` バッチ → assemble 結果が同期パスと一致
-- 詰まり検知: 経過2日超で warning が出る
+- sidecar（マニフェスト含む）の read/write/delete ラウンドトリップ
+- poll: 予算切れで raise/cancel せず pending を返す
+- resume assemble: sidecar + mocked `ended` バッチ → **再グルーピングなしで** 同期パスと一致する thread を生成
+- silent-corruption ガード: マニフェストの custom_id 対応のみで解決し、グルーパーを呼ばないこと
+- retry: expired を 3 回で hard fail（exit 非ゼロ）
+- 詰まり検知: 経過2日超で warning/issue 経路が起動
 - `ci.yml` に pytest ステップを追加
 
 ## 影響ファイル
 
 | ファイル | 変更内容 |
 | --- | --- |
-| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に変更。cancel は expired 時のみ |
-| `scripts/summarize.py` | sidecar load/save/delete、resume 分岐、再 prepare パス、batch_pending → exit 0、クリーンアップ除外 |
-| `.github/workflows/daily-batch.yml` | 詰まり検知ステップ追加（sidecar 経過スキャン → Issue #41 コメント） |
+| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に。cancel は expired 時のみ |
+| `scripts/summarize.py` | sidecar(マニフェスト) load/save/delete、early commit、resume assemble（再グルーピングなし）、グローバル poll 予算、batch_pending→exit 0、retry/hard-fail、クリーンアップ除外、auto-resume 拡張 |
+| `.github/workflows/daily-batch.yml` | early sidecar commit 機構、詰まり検知ステップ（sidecar 走査→Issue #41）、グローバル予算の env |
 | `scripts/tests/`（新規） | pytest + fake client |
 | `.github/workflows/ci.yml` | pytest ステップ追加 |
 | `README` 監視節 / メモリ `project_daily_batch_failures` | 根治済みに更新 |
 
 ## エラーハンドリング / エッジケース
 
-- **GHA が poll 中に 120分で kill**: sidecar は submit 直後に書くが、commit/push に到達しないと永続しない。
-  poll 予算 20分はこの 120分上限に対し十分な余裕を残すため到達は保証される。
+- **GHA が poll 中に 120分で kill**: sidecar は early commit 済みのため永続。次 run が resume。
+- **set -e で後続ステップが失敗**: sidecar は early commit 済みのため永続。
 - **バッチが run 間で完了済み（夜間）**: resume run が `ended` を即検出 → 待機なしで assemble。
-- **expired（24h 超）**: 毎日 run するので通常は到達しない。到達時は放棄 + 再 submit（一度きりの無駄、稀）。
-- **同日付に新規 meeting が増える**: 旧日付（例 2026-05-14）への新規追加は稀。in-flight 解決後に拾う。
-- **モデル更新で再 prepare の custom_id が変わる**: 同一モデル & 1〜2日以内なので決定論性は保たれる。
-  不一致が起きた custom_id はマッチせず skip ログ（既存挙動）に落ち、次 window で再取得される。
+- **expired/canceled の継続**: §6 の retry_count で 3 回到達時 hard fail（無限ループ/二重課金を遮断）。
+- **raw data の不変性**: 過去日付の raw data は fetch 後に確定・コミットされ変化しない、という前提に依存。
+  この前提が崩れる（source adapter の正規化変更等）と speechOrders 参照がズレる可能性があるため、
+  spec の前提として明記する。万一マニフェストの speechOrder が raw_lookup に存在しなければ
+  その thread は skip ログ（既存挙動）に落とし、meeting は次 window で再取得される。
+- **同日付に新規 meeting が増える**: in-flight 中は新規 submit しない（§3）。解決後の run で拾う。
 
 ## 非目標（YAGNI）
 
 - 1日付で複数 in-flight バッチを並走させること。
 - 同期（非バッチ）フォールバック。
-- prepared context のフル永続化（決定論的 再 prepare で代替するため不要）。
+- speech 本文を含むフル文脈の永続化（マニフェストで代替）。
+- `batches.list()` による orphan リコンシリエーション（early commit + グローバル予算で窓をほぼゼロにする方針を採用。
+  将来必要になれば別途追加）。
+
+## レビュー反映（codex external review, 2026-06-12）
+
+- **Critical**: custom_id 位置依存による silent corruption → §0 で再グルーピング案を撤回しマニフェスト永続化に変更。
+- **Critical**: sidecar 永続化境界 → §2 で early commit を導入。
+- **Important**: per-date poll 加算 → §3 でグローバル予算化＋pending 後の新規 submit 停止。
+- **Important**: expired 再 submit の二重課金/無限ループ → §6 で retry_count 3 回 hard fail。
+- **Important**: 「commit 到達保証」の言い切り → §2 で永続化境界を明示する記述に修正。
+- **Question**: raw payload 再取得の安定性 → エッジケースで前提を明記。
+- **Question**: batch_pending 時の出力 → §5 で「空 `{date}.json` を作らず sidecar のみ」と明示。

--- a/docs/superpowers/specs/2026-06-12-batch-resume-design.md
+++ b/docs/superpowers/specs/2026-06-12-batch-resume-design.md
@@ -1,0 +1,150 @@
+# バッチID永続化による run 横断 resume 設計
+
+- 日付: 2026-06-12
+- 対象: `scripts/summarize.py --batch` のサマリフェーズ
+- 関連 Issue: #41 (`pipeline-failure`)
+- 直前コミット: `58c0ed9 fix(pipeline): cancel timed-out summary batches and repair failure alerting`
+
+## 背景と問題
+
+daily-batch ワークフローが 2026-06-10・06-11 と2日連続で約1時間34分かけて失敗した。
+原因は Anthropic Message Batches API のバッチ（54リクエスト）が 90分（5400s）のポーリング
+上限を超えても `in_progress` のまま終わらず、`58c0ed9` で導入したタイムアウト処理が
+**設計通りに** バッチを cancel して `TimeoutError` で exit 1 → CI 赤になったこと。
+
+`58c0ed9` は「タイムアウトしたバッチが課金され続ける」問題を解いたが、その代償として
+**「90分待てば完了したはずのバッチを毎回捨てる」** 挙動になった。`batch_id` は
+`run_batch_phase`（`scripts/summarize.py:443`）のローカル変数で、次回 run に引き継がれない。
+
+この結果、Anthropic 側の混雑が続く間は次のループに陥る:
+
+```
+submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を submit → …
+```
+
+混雑が続く限りデータが一切前進しない。これは構造的な弱点であり、根治は
+**batch_id の永続化による run 横断 resume**（メモ `project_daily_batch_failures` が既に指摘）。
+
+## 不変条件（プロジェクト制約）
+
+- サマリ層は **stateless / deterministic / prompt-only**（CLAUDE.md「Summary Layer Invariants」）。
+  グルーピングと outcome 抽出は temperature=0 で決定論的。本設計はこの決定論性を活用する。
+- GitHub Actions runner は使い捨て。run 横断で状態を渡すには **リポジトリへ commit & push** する必要がある。
+- daily-batch.yml は `set -e` のシェルループで日付ごとに `summarize.py --date $d --batch` を呼ぶ。
+  非ゼロ終了でループ全体が失敗する。GHA `timeout-minutes: 120`。
+
+## 既存の永続化メカニズム（重要な区別）
+
+- `{date}.progress.json`: **run 内専用**。成功時に `summarize.py:713-714` で `os.remove` され、git 管理外。
+  プロセスクラッシュ/リトライ時の run 内 resumability 用。
+- **run 横断の状態**: コミット済みの `{date}.json`（threads ファイル）。
+  既に表現されている meeting＝完了、として `summarize.py:587-604` の auto-resume が再導出する。
+
+→ batch_id を progress.json に置くと成功時に消える/コミットされないため引き継げない。
+**意図的にコミットする専用 sidecar が必要。**
+
+## 設計
+
+### 1. 永続化フォーマット（sidecar）
+
+日付ごとに `data/threads/{date}.pending-batch.json`:
+
+```json
+{
+  "batch_id": "msgbatch_01HBjNG4...",
+  "meeting_ids": ["参議院_外交防衛委員会_2026-05-14_第8号", "..."],
+  "model": "claude-...",
+  "submitted_at": "2026-06-11T21:50:15Z"
+}
+```
+
+- `submit_summary_batch` の **直後**（ポーリング前）に書き込む。
+- `data/threads/` は既に `git add data/threads/` 対象なので自動でコミット & push される。
+- 結果の回収・assemble 完了時、または恒久放棄（expired/canceled）時に削除する。
+- `summarize.py:682` の `.json` クリーンアップ glob が拾わないよう、`.progress.json` と同様に
+  `.pending-batch.json` を明示除外する。
+
+### 2. `poll_summary_batch` の挙動変更（`scripts/pipeline/summarizer.py`）
+
+- 現状: タイムアウト時に `client.messages.batches.cancel` + `raise TimeoutError`。
+- 変更後: タイムアウト時は **raise も cancel もせず**、終了状態を返す
+  （例: 戻り値で `ended` 完了か、予算切れの `pending` かを呼び出し側が判別できるようにする）。
+- `cancel` は恒久放棄（`expired` 等）時のみ。
+- `58c0ed9` の cancel を巻き戻すが正当: resume で結果を実際に使うため「無駄課金」懸念は消える。
+
+### 3. poll 予算（per-run）
+
+- デフォルト **20分**（1200s）。env で可変（既存の `batch_timeout_seconds` 系パラメータを流用/改名）。
+- 健全なバッチは 3〜7分で完了 → 従来通り **同一 run で回収**（通常日のデータ遅延ゼロ）。
+- 混雑時は 20分で exit 0 → 翌 run で resume。
+- 複数日付が未処理でも 3日付 × 20分 = 60分 < GHA 120分上限。commit/push ステップに必ず到達する。
+
+### 4. resume フロー（`run_batch_phase` 冒頭に追加）
+
+```
+sidecar を load。存在すれば:
+  retrieve(batch_id):
+    ended            → meeting_ids を再 prepare（決定論で同一 custom_id を再構築）
+                       → fetch_summary_results → assemble → threads 追記
+                       → meetings を completed に → sidecar 削除
+                       → その後、新規 meeting があれば通常の prepare + submit へ
+    in_progress      → poll 予算まで待つ。完了すれば上と同様に assemble。
+                       未完なら sidecar 据え置き・batch_pending=True で返す（同日付の新規 submit はしない）
+    canceled/expired → warning, sidecar 削除（放棄。次回 window fetch で再取得・再 submit）
+```
+
+- 不変条件: **1日付につき同時に in-flight バッチは1つ**。in-flight 中は同日付の新規 submit をしない。
+
+### 5. exit 0 のシグナリング（`scripts/summarize.py`）
+
+- `run_batch_phase` が `batch_pending=True` を返したら、main は出力を書き、sidecar を残し **exit 0**。
+- `os.remove(progress_path)` 等のクリーンアップで sidecar を削除しないこと。
+- pending 状態は「失敗」ではなく「正常な非同期待ち」として扱う（CI 緑）。
+
+### 6. 詰まり検知アラート
+
+- sidecar の `submitted_at` が **2日以上前**（daily run 2回を越えて未完）なら「本当に詰まった」と判断。
+- 実装: daily-batch.yml に軽量ステップを追加し、`data/threads/*.pending-batch.json` の経過日数を
+  スキャン → 2日超なら `gh issue comment`（既存 Issue #41 / `pipeline-failure` ラベル）で
+  batch_id と経過を通知。
+- 既存 `notify-on-failure`（`if: failure()`）は exit 0 化のため発火しなくなるので、この別経路が必要。
+  `GH_REPO: ${{ github.repository }}` 設定を流用する。
+
+### 7. テスト（pytest 基盤を新設）
+
+現状 Python テストは無し（`tests/unit/ministry.test.mjs` のみ）。最小 pytest を `scripts/tests/` に新設し、
+fake Anthropic client を用いる:
+
+- sidecar の read/write/delete ラウンドトリップ
+- poll: タイムアウトで raise/cancel せず pending を返す
+- 決定論: 同一 meeting の再 prepare が同一 custom_id を生む
+- resume: sidecar + mocked `ended` バッチ → assemble 結果が同期パスと一致
+- 詰まり検知: 経過2日超で warning が出る
+- `ci.yml` に pytest ステップを追加
+
+## 影響ファイル
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に変更。cancel は expired 時のみ |
+| `scripts/summarize.py` | sidecar load/save/delete、resume 分岐、再 prepare パス、batch_pending → exit 0、クリーンアップ除外 |
+| `.github/workflows/daily-batch.yml` | 詰まり検知ステップ追加（sidecar 経過スキャン → Issue #41 コメント） |
+| `scripts/tests/`（新規） | pytest + fake client |
+| `.github/workflows/ci.yml` | pytest ステップ追加 |
+| `README` 監視節 / メモリ `project_daily_batch_failures` | 根治済みに更新 |
+
+## エラーハンドリング / エッジケース
+
+- **GHA が poll 中に 120分で kill**: sidecar は submit 直後に書くが、commit/push に到達しないと永続しない。
+  poll 予算 20分はこの 120分上限に対し十分な余裕を残すため到達は保証される。
+- **バッチが run 間で完了済み（夜間）**: resume run が `ended` を即検出 → 待機なしで assemble。
+- **expired（24h 超）**: 毎日 run するので通常は到達しない。到達時は放棄 + 再 submit（一度きりの無駄、稀）。
+- **同日付に新規 meeting が増える**: 旧日付（例 2026-05-14）への新規追加は稀。in-flight 解決後に拾う。
+- **モデル更新で再 prepare の custom_id が変わる**: 同一モデル & 1〜2日以内なので決定論性は保たれる。
+  不一致が起きた custom_id はマッチせず skip ログ（既存挙動）に落ち、次 window で再取得される。
+
+## 非目標（YAGNI）
+
+- 1日付で複数 in-flight バッチを並走させること。
+- 同期（非バッチ）フォールバック。
+- prepared context のフル永続化（決定論的 再 prepare で代替するため不要）。

--- a/docs/superpowers/specs/2026-06-12-batch-resume-design.md
+++ b/docs/superpowers/specs/2026-06-12-batch-resume-design.md
@@ -4,62 +4,52 @@
 - 対象: `scripts/summarize.py --batch` のサマリフェーズ
 - 関連 Issue: #41 (`pipeline-failure`)
 - 直前コミット: `58c0ed9 fix(pipeline): cancel timed-out summary batches and repair failure alerting`
-- レビュー: codex external review 反映済み（後述「レビュー反映」）
+- レビュー: codex external review 2回反映済み（後述「レビュー反映」）
 
 ## 背景と問題
 
 daily-batch ワークフローが 2026-06-10・06-11 と2日連続で約1時間34分かけて失敗した。
 原因は Anthropic Message Batches API のバッチ（54リクエスト）が 90分（5400s）のポーリング
-上限を超えても `in_progress` のまま終わらず、`58c0ed9` で導入したタイムアウト処理が
-**設計通りに** バッチを cancel して `TimeoutError` で exit 1 → CI 赤になったこと。
+上限を超えても `in_progress` のまま終わらず、`58c0ed9` のタイムアウト処理が **設計通りに**
+バッチを cancel して `TimeoutError` で exit 1 → CI 赤になったこと。
 
 `58c0ed9` は「タイムアウトしたバッチが課金され続ける」問題を解いたが、その代償として
 **「90分待てば完了したはずのバッチを毎回捨てる」** 挙動になった。`batch_id` は
-`run_batch_phase`（`scripts/summarize.py:443`）のローカル変数で、次回 run に引き継がれない。
+`run_batch_phase`（`scripts/summarize.py:443`）のローカル変数で次回 run に引き継がれず、
+混雑が続く間は `submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を submit` の
+デッドロックに陥る。根治は **batch_id の永続化による run 横断 resume**。
 
-この結果、Anthropic 側の混雑が続く間は次のループに陥る:
-
-```
-submit → 90分待つ → cancel → 失敗 → 翌日また同じ meeting を submit → …
-```
-
-混雑が続く限りデータが一切前進しない。根治は **batch_id の永続化による run 横断 resume**。
-
-## 不変条件（プロジェクト制約）
+## 不変条件 / 現状把握（実コード検証済み）
 
 - サマリ層は **stateless / deterministic / prompt-only**（CLAUDE.md「Summary Layer Invariants」）。
-  本設計は run 横断状態を sidecar に持つが、それは「未完バッチの回収先」を指すポインタ＋
-  「submit 時に確定した入力の写し」であり、サマリ**内容**を run 間で変化させない（同一入力→同一出力を保つ）。
-- GitHub Actions runner は使い捨て。run 横断で状態を渡すには **リポジトリへ commit & push** する必要がある。
-- daily-batch.yml は `set -e` のシェルループで日付ごとに `summarize.py --date $d --batch` を呼ぶ。
-  非ゼロ終了でループ全体が失敗する。GHA `timeout-minutes: 120`。
+  sidecar は「未完バッチの回収先ポインタ＋submit 時に確定した入力の写し」であり、サマリ**内容**を
+  run 間で変化させない（同一入力→同一出力を保つ）。
+- GitHub Actions runner は使い捨て。run 横断状態は **commit & push** でしか渡せない。
+- `daily-batch.yml` は1つの job 内で `for d in $DATES_LIST; do python summarize.py --date "$d" --batch; done`
+  と **日付ごとに別プロセス**で呼ぶ（`set -e`）。GHA `timeout-minutes: 120`。
+- job permissions は `contents: write` のみ。`issues: write` は別 job `notify-on-failure` だけが持つ。
+- `data/raw/` は **リポジトリにコミットされていない**（追跡0件）。raw は run ごとに NDL 等から再 fetch される。
+- `concurrency:` 設定は無い（overlapping run があり得る）。
+- 既存 `{date}.progress.json` は **run 内専用**（成功時 `summarize.py:713-714` で削除、git 管理外）。
+  run 横断完了判定はコミット済み `{date}.json` から再導出（`summarize.py:587-604`）。
 
-## 既存の永続化メカニズム（重要な区別）
-
-- `{date}.progress.json`: **run 内専用**。成功時に `summarize.py:713-714` で `os.remove` され、git 管理外。
-- **run 横断の状態**: コミット済みの `{date}.json`（threads ファイル）。
-  既に表現されている meeting＝完了、として `summarize.py:587-604` の auto-resume が再導出する。
-
-→ batch_id を progress.json に置くと成功時に消える/コミットされないため引き継げない。
-**意図的にコミットする専用 sidecar が必要。**
+→ batch_id を progress.json に置くと引き継げない。**意図的にコミットする専用 sidecar が必要。**
 
 ## 設計
 
-### 0. なぜ「再グルーピング」ではなくマニフェスト永続化か（最重要）
+### 0. なぜ「再グルーピング」ではなくマニフェスト永続化か
 
 `make_batch_custom_id(meeting_id, idx)`（`summarize.py:338-346`）= `s_{sha256(meeting_id)[:12]}_{idx:02d}`。
-custom_id は **meeting_id とスレッド位置インデックスのみ**で、スレッド内容・speechOrders・topic を含まない。
+custom_id は **meeting_id とスレッド位置インデックスのみ**で、内容を含まない。
 
-したがって resume 時に「再グルーピングして custom_id を再構築」する案は危険:
-グルーピング結果が1つでもズレると、custom_id は**位置ベースで常にマッチする**ため
-`results.get(custom_id)` は成功し、**古いサマリ結果を新しい thread_info に貼り付ける
-silent data corruption** になる（skip されない）。temperature=0 でも完全な決定論は保証されず、
-モデル更新では確実に破綻する。これはサマリ層の中立性・透明性保証を破る。
+resume 時に「再グルーピングして custom_id を再構築」すると、グルーピング結果が1つでもズレた場合に
+custom_id は**位置ベースで常にマッチ**し、`results.get(custom_id)` が成功して
+**古いサマリを新しい thread_info に貼り付ける silent corruption** になる（skip されない）。
+temperature=0 でも完全な決定論は保証されず、モデル更新では確実に破綻する。
 
-**解決**: submit 時点で確定したグルーピング・マニフェストを sidecar に永続化し、
-resume 時は**再グルーピングせず**マニフェストどおりに assemble する。
-これは ①決定論依存を完全排除 ②resume 時のグルーパー/outcome LLM 呼び出し（コスト/時間）を省略
-③speech 本文は持たず sidecar を小さく保つ、を同時に満たす。
+**解決**: submit 時点で確定したグルーピング・マニフェストを sidecar に永続化し、resume 時は
+**再グルーピングせず**マニフェストどおりに assemble する。決定論依存を排除し、resume 時の
+グルーパー/outcome LLM 呼び出しも省ける。
 
 ### 1. 永続化フォーマット（sidecar）
 
@@ -67,147 +57,177 @@ resume 時は**再グルーピングせず**マニフェストどおりに assem
 
 ```json
 {
-  "batch_id": "msgbatch_01HBjNG4...",
+  "schema_version": 1,
   "model": "claude-...",
-  "submitted_at": "2026-06-11T21:50:15Z",
   "retry_count": 0,
-  "last_terminal_status": null,
+  "attempts": [
+    {
+      "batch_id": "msgbatch_01HBjNG4...",
+      "submitted_at": "2026-06-11T21:50:15Z",
+      "terminal_status": null,
+      "terminal_at": null
+    }
+  ],
   "meetings": [
     {
       "meeting_id": "参議院_外交防衛委員会_2026-05-14_第8号",
       "outcome": { "result": null, "resolution": null, "status": "ongoing" },
       "threads": [
-        { "custom_id": "s_ab12cd34ef56_00", "thread_idx": 0, "topic": "…", "speechOrders": [12, 13, 14] }
+        {
+          "custom_id": "s_ab12cd34ef56_00",
+          "thread_idx": 0,
+          "topic": "…",
+          "speechOrders": [12, 13, 14],
+          "input_hash": "sha256:…"
+        }
       ]
     }
   ]
 }
 ```
 
-- speech 本文は持たない。`speechOrders` は raw_lookup への int 参照。resume 時に
-  raw data（コミット済みで不変）から `build_speech_lookup` を再構築して thread_speeches を引く。
-- `submit_summary_batch` の **直後**（ポーリング前）に書き込む。
-- `data/threads/` は `git add data/threads/` 対象。回収完了時・恒久放棄時に削除する。
-- `summarize.py:682` の `.json` クリーンアップ glob が拾わないよう、`.progress.json` と同様に
-  `.pending-batch.json` を明示除外する。
+- **`input_hash`（C2 対策）**: submit 時にそのスレッドの batch request 入力（thread_speeches の本文＋
+  プロンプト構築に使う確定要素）を正規化して取った SHA256。speech 本文そのものは持たない（sidecar を小さく保つ）。
+- **`attempts[]`（I5 対策）**: バッチ投入の履歴。再 submit 時は新しい attempt を push（古い batch_id は履歴に残す）。
+  現在の in-flight は `attempts[-1]`。`retry_count` は terminal 非成功で +1。
+- `data/threads/` は `git add data/threads/` 対象。回収完了時・恒久放棄時に sidecar を削除。
+- `summarize.py:682` の `.json` クリーンアップ glob が拾わないよう `.pending-batch.json` を明示除外。
 
-### 2. 永続化境界（orphan 防護）
+### 2. 永続化境界（orphan 防護 / C2・C3）
 
-**問題**: submit 直後の sidecar 書き込みは、workflow 末尾の commit & push に到達して初めて
-リポジトリに残る。途中で kill / `set -e` の後続失敗 / push 衝突が起きると、Anthropic 側に
-バッチは在るが sidecar が残らず **orphan（課金済み・回収不能）** になる。
-「poll 予算が短いから commit に到達する」だけでは保証にならない。
+**問題**: submit 直後の sidecar 書き込みは workflow 末尾の commit & push まではリポジトリに残らない。
+途中 kill / `set -e` 後続失敗 / push 衝突で sidecar が残らないと、Anthropic 側にバッチは在るのに
+回収不能な **orphan（課金済み）** になる。さらに `data/raw/` は非コミットなので、resume 時の raw は
+別 fetch であり、submit 時スナップショットと一致する保証がない。
 
 **対策**:
-1. **early commit**: sidecar を書いた直後、**長い poll に入る前に** sidecar だけを対象に
-   `git add <sidecar> && git commit && git push` を実行する（永続化境界を poll の前に移す）。
-   - 実装機構は writing-plans で確定。候補: (a) summarize.py が submit 後に targeted git push、
-     (b) workflow を「submit パス → sidecar commit → poll/collect パス」に分割。
-     最小変更は (a)。push 競合時は fast-forward リトライ。
-2. **グローバル poll 予算**: 後述（§3）。poll を per-date 加算ではなく per-run 全体で bound し、
-   120分上限到達前に確実に collect/commit ステップへ戻れるようにする。
+1. **early commit（CI 専用）**: sidecar を書いた直後、長い poll の前に sidecar だけを
+   `git add <sidecar> && git commit && git push`。ローカル実行では push しない（`CI` env / 明示フラグで gate）。
+   永続化境界を poll の前へ移す。
+2. **input_hash 照合（§4）**: resume 時に再 fetch した raw から thread_speeches を再構築し input_hash を再計算、
+   sidecar と一致した場合のみ assemble。raw 経路の silent corruption を閉じ、「raw 不変」前提への依存を消す。
+3. **concurrency ロック（C3）**: `daily-batch.yml` に `concurrency: { group: daily-batch, cancel-in-progress: false }`
+   を追加。さらに submit 直前に最新 sidecar を recheck（既に in-flight があれば submit しない）。
 
-これにより orphan 窓はほぼゼロ。万一 early commit 前に kill されても、再 submit は次 window で
-冪等に行われる（同一 window の meeting が再取得されるため）。
+### 3. poll 予算と「pending 後 submit 停止」（C1）
 
-### 3. poll 予算（per-run グローバル）
+per-run のグローバル挙動を、**別プロセスの日付ループでも成立させる**ため workflow 側で制御する:
 
-- **per-run 全体**で1つの予算。デフォルト **30分**（env 可変）。per-date 加算にしない。
-- 健全なバッチは 3〜7分で完了 → 従来通り **同一 run で回収**（通常日のデータ遅延ゼロ）。
-- 予算を使い切ったら、未完バッチの sidecar を据え置き **exit 0** で抜ける（翌 run で resume）。
-- pending が1件でも発生したら、その run ではそれ以上の**新規 submit を行わない**
-  （複数 in-flight の積み増しを防ぎ、予算と orphan 窓を抑える）。
-- 30分 << GHA 120分。fetch/enrich/validate/commit/push に十分な余裕を残す。
+1. **pre-collect ステップ（run 冒頭）**: `DATES_LIST` とは独立に `data/threads/*.pending-batch.json` を
+   走査し、既存 in-flight バッチを retrieve。ended は assemble、in_progress はグローバル予算内で待つ
+   （§4）。ここで予算を消費する。
+2. **submit ループ**: その後 `for d in $DATES_LIST` を回すが、ある日付の summarize.py が
+   **pending を返した（sidecar 新規作成）時点で shell ループを break**（以降の新規 submit をしない）。
+   summarize.py は「pending か否か」を終了コードまたは marker で workflow に伝える（exit 0 維持、
+   別経路で signal）。
+3. **グローバル予算**: 既定 **30分**（env 可変）。pre-collect と最初の submit-poll の合計をこの予算で bound。
+   30分 << 120分で、後続 enrich/validate/commit/push に余裕を残す。
 
-### 4. resume フロー
+健全なバッチ（3〜7分）は同一 run で回収され、通常日のデータ遅延はゼロ。
 
-run 開始時、コミット済み sidecar を走査する。日付ごとに:
+### 4. resume / assemble フロー
+
+pre-collect で各 sidecar の `attempts[-1].batch_id` を retrieve():
 
 ```
-sidecar.batch_id を retrieve():
-  ended            → マニフェストどおり assemble:
-                       各 meeting の raw data を再取得 → build_speech_lookup
-                       → 各 thread の speechOrders で thread_speeches を引く
-                       → fetch_summary_results(batch_id) の結果を custom_id で対応付け
-                       → persisted topic / outcome と合わせて thread 組み立て
-                       → threads 追記、meeting を completed に、sidecar 削除
-  in_progress      → グローバル poll 予算内で待つ。完了すれば上と同様に assemble。
-                       予算切れなら sidecar 据え置き、batch_pending=True を立てる
-  canceled/expired → retry 処理（§6）
+ended:
+  各 meeting の raw を再 fetch → build_speech_lookup
+  各 thread: speechOrders で thread_speeches を引き、input_hash を再計算
+    - sidecar の input_hash と不一致、または speechOrder 欠落 → assemble 失敗（§6 へ）
+  fetch_summary_results(batch_id) を custom_id で対応付け
+    - manifest の全 custom_id が結果に揃っているか確認（I6）
+      欠落があれば meeting を completed にせず sidecar を保持（§6 へ）
+  全て揃い・全 hash 一致 → persisted topic/outcome と合わせて thread 組み立て
+  → threads 追記、meeting を completed、（全 meeting 完了で）sidecar 削除
+in_progress: グローバル予算内で待つ。完了すれば上と同様。予算切れは sidecar 据え置き・pending signal。
+canceled/expired: §6（retry）。
 ```
 
-- assemble は**再グルーピングを行わない**（§0）。custom_id は sidecar の対応表のみで解決する。
-- 不変条件: **1日付につき同時に in-flight バッチは1つ**。
+- assemble は **再グルーピングを行わない**。custom_id は manifest の対応表のみで解決。
+- 不変条件: **1日付につき同時 in-flight バッチは1つ**（`attempts[-1]` のみ）。
 
 ### 5. exit 0 と「何を書くか」
 
-- `run_batch_phase` が `batch_pending=True` を返したら、main は **exit 0**（pending は失敗でなく非同期待ち）。
-- pending のみで完了 thread が無い日付は、**空の `{date}.json` を作らない**。sidecar だけを残す。
-  auto-resume（`summarize.py:587-604`）は「sidecar あり / threads ファイル無し」を許容するよう拡張する。
-- `os.remove(progress_path)` 等のクリーンアップで sidecar を削除しないこと。
+- pending（予算切れで未完）でも **exit 0**（失敗でなく非同期待ち）。workflow へは別 signal で pending を伝える（§3-2）。
+- 完了 thread が無い日付は **空の `{date}.json` を作らない**。sidecar だけを残す。
+  auto-resume（`summarize.py:587-604`）は「sidecar あり / threads ファイル無し」を許容するよう拡張。
+- クリーンアップで sidecar を削除しないこと。
 
 ### 6. retry / 詰まり検知 / エスカレーション
 
-- **terminal 非成功（expired/canceled）**: 該当バッチを放棄して sidecar の `retry_count` を +1、
-  `last_terminal_status` を記録し、同 window の meeting を次の submit 機会で投げ直す。
-- **3回連続**（同一日付で expired/canceled が 3 回）→ **hard fail（exit 非ゼロ・CI 赤）**。
-  Issue #41 に batch 履歴と retry 回数を明示し、人間の介入を促す。緑のままデータ停滞を防ぐ。
-- **詰まり検知（in_progress が長期化）**: sidecar の `submitted_at` が **2日超**なら、
-  daily-batch.yml の軽量ステップが `data/threads/*.pending-batch.json` を走査して
-  `gh issue comment`（Issue #41 / `pipeline-failure`）で通知。
-  既存 `notify-on-failure`（`if: failure()`）は exit 0 化で発火しなくなるため、この別経路が必要。
-  `GH_REPO: ${{ github.repository }}` を流用。
+- **assemble 失敗（input_hash 不一致 / custom_id 欠落 / 一部 request failed）**: meeting を completed にせず
+  sidecar を保持。該当 attempt を terminal 失敗として記録（`attempts[-1].terminal_status`）。
+- **terminal 非成功（expired/canceled/assemble失敗）**: `retry_count` +1。次の submit 機会で投げ直し、
+  新しい attempt を push。
+- **3回連続**（同一日付で terminal 非成功が 3 回）→ **hard fail（exit 非ゼロ・CI 赤）**。
+  `attempts[]` 履歴と `retry_count` を Issue #41 に明示し人間の介入を促す（緑のままのデータ停滞を防ぐ）。
+- **詰まり検知（in_progress 長期化）**: `attempts[-1].submitted_at` が **2日超**なら、
+  `data/threads/*.pending-batch.json` を走査する軽量ステップが `gh issue comment`（Issue #41）で通知。
+  - exit 0 化で `notify-on-failure`（`if: failure()`）は発火しないため別経路。
+  - **この通知ステップ/ジョブには `issues: write` と `GH_TOKEN`・`GH_REPO` を明示**（I4。
+    fetch-and-summarize job は `contents: write` のみのため、専用 job 化するか job 権限を拡張する）。
 
 ### 7. テスト（pytest 基盤を新設）
 
 現状 Python テストは無し（`tests/unit/ministry.test.mjs` のみ）。最小 pytest を `scripts/tests/` に新設し、
 fake Anthropic client を用いる:
 
-- sidecar（マニフェスト含む）の read/write/delete ラウンドトリップ
+- sidecar（attempts/manifest）の read/write/delete ラウンドトリップ
 - poll: 予算切れで raise/cancel せず pending を返す
-- resume assemble: sidecar + mocked `ended` バッチ → **再グルーピングなしで** 同期パスと一致する thread を生成
-- silent-corruption ガード: マニフェストの custom_id 対応のみで解決し、グルーパーを呼ばないこと
-- retry: expired を 3 回で hard fail（exit 非ゼロ）
-- 詰まり検知: 経過2日超で warning/issue 経路が起動
-- `ci.yml` に pytest ステップを追加
+- resume assemble: sidecar + mocked `ended` → **再グルーピングなしで**同期パスと一致
+- **input_hash ガード（C2）**: raw を改変したケースで hash 不一致 → assemble せず sidecar 保持
+- **完全性（I6）**: 一部 custom_id 欠落 → meeting を completed にせず sidecar 保持
+- silent-corruption ガード: custom_id 対応のみで解決しグルーパーを呼ばない
+- retry: terminal 非成功 3 回で hard fail（exit 非ゼロ）
+- 詰まり検知: 経過2日超で通知経路が起動
+- `ci.yml` に pytest ステップ追加
 
 ## 影響ファイル
 
 | ファイル | 変更内容 |
 | --- | --- |
-| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に。cancel は expired 時のみ |
-| `scripts/summarize.py` | sidecar(マニフェスト) load/save/delete、early commit、resume assemble（再グルーピングなし）、グローバル poll 予算、batch_pending→exit 0、retry/hard-fail、クリーンアップ除外、auto-resume 拡張 |
-| `.github/workflows/daily-batch.yml` | early sidecar commit 機構、詰まり検知ステップ（sidecar 走査→Issue #41）、グローバル予算の env |
+| `scripts/pipeline/summarizer.py` | `poll_summary_batch` を「状態を返す」方式に。cancel は不要に |
+| `scripts/summarize.py` | sidecar(attempts/manifest+input_hash) load/save/delete、early commit(CI gate)、resume assemble（再グルーピングなし・hash照合・完全性チェック）、pending signal、retry/hard-fail、クリーンアップ除外、auto-resume 拡張 |
+| `.github/workflows/daily-batch.yml` | `concurrency:` 追加、pre-collect ステップ、submit ループの break-on-pending、early commit 連携、詰まり検知ステップ（`issues: write` 付き）、グローバル予算 env |
 | `scripts/tests/`（新規） | pytest + fake client |
 | `.github/workflows/ci.yml` | pytest ステップ追加 |
 | `README` 監視節 / メモリ `project_daily_batch_failures` | 根治済みに更新 |
 
 ## エラーハンドリング / エッジケース
 
-- **GHA が poll 中に 120分で kill**: sidecar は early commit 済みのため永続。次 run が resume。
-- **set -e で後続ステップが失敗**: sidecar は early commit 済みのため永続。
-- **バッチが run 間で完了済み（夜間）**: resume run が `ended` を即検出 → 待機なしで assemble。
-- **expired/canceled の継続**: §6 の retry_count で 3 回到達時 hard fail（無限ループ/二重課金を遮断）。
-- **raw data の不変性**: 過去日付の raw data は fetch 後に確定・コミットされ変化しない、という前提に依存。
-  この前提が崩れる（source adapter の正規化変更等）と speechOrders 参照がズレる可能性があるため、
-  spec の前提として明記する。万一マニフェストの speechOrder が raw_lookup に存在しなければ
-  その thread は skip ログ（既存挙動）に落とし、meeting は次 window で再取得される。
-- **同日付に新規 meeting が増える**: in-flight 中は新規 submit しない（§3）。解決後の run で拾う。
+- **GHA が 120分 kill / set -e 後続失敗**: sidecar は early commit 済みのため永続。次 run が resume。
+- **raw が submit 時から変化**: input_hash 不一致で assemble せず保持（silent corruption を遮断、§6）。
+- **ended batch の一部欠落**: 全 custom_id 揃いを completion 条件にし、欠落は保持（I6/§6）。
+- **overlapping run**: `concurrency` ロック＋submit 直前 recheck で重複 submit を防止（C3）。
+- **expired/canceled の継続**: retry_count 3 回で hard fail（無限ループ/二重課金を遮断）。
+- **夜間に完了**: resume run が `ended` を即検出 → 待機なしで assemble。
 
 ## 非目標（YAGNI）
 
 - 1日付で複数 in-flight バッチを並走させること。
 - 同期（非バッチ）フォールバック。
-- speech 本文を含むフル文脈の永続化（マニフェストで代替）。
-- `batches.list()` による orphan リコンシリエーション（early commit + グローバル予算で窓をほぼゼロにする方針を採用。
-  将来必要になれば別途追加）。
+- speech 本文を含むフル文脈の永続化（manifest＋input_hash で代替）。
+- `batches.list()` による orphan リコンシリエーション（early commit + concurrency + グローバル予算で窓を
+  ほぼゼロにする方針。将来必要になれば追加）。
 
-## レビュー反映（codex external review, 2026-06-12）
+## レビュー反映
 
-- **Critical**: custom_id 位置依存による silent corruption → §0 で再グルーピング案を撤回しマニフェスト永続化に変更。
-- **Critical**: sidecar 永続化境界 → §2 で early commit を導入。
-- **Important**: per-date poll 加算 → §3 でグローバル予算化＋pending 後の新規 submit 停止。
-- **Important**: expired 再 submit の二重課金/無限ループ → §6 で retry_count 3 回 hard fail。
-- **Important**: 「commit 到達保証」の言い切り → §2 で永続化境界を明示する記述に修正。
-- **Question**: raw payload 再取得の安定性 → エッジケースで前提を明記。
-- **Question**: batch_pending 時の出力 → §5 で「空 `{date}.json` を作らず sidecar のみ」と明示。
+### 1回目（codex, 2026-06-12）
+- Critical: custom_id 位置依存 silent corruption → §0 マニフェスト永続化へ変更。
+- Critical: sidecar 永続化境界 → §2 early commit 導入。
+- Important: per-date poll 加算 → グローバル予算化。
+- Important: expired 再 submit の二重課金/無限ループ → §6 retry 3 回 hard fail。
+- Question: raw 安定性 / batch_pending 出力 → 明文化。
+
+### 2回目（codex, 2026-06-12）
+- **Critical C1**: 別プロセス日付ループでグローバル予算/submit 停止が不成立 → §3 で workflow pre-collect ＋
+  break-on-pending ＋グローバル予算に変更。
+- **Critical C2**: sidecar/raw 非原子（raw 非コミット）→ raw 経路の silent corruption → §1 `input_hash`＋
+  §4 照合で遮断。
+- **Critical C3**: concurrency ロック無し → 重複 submit/orphan → §2 `concurrency:`＋submit 直前 recheck。
+- **Important I4**: 詰まり通知 step の `issues: write` 不足 → §6 で権限明示/専用 job 化。
+- **Important I5**: retry schema 不足 → §1 `attempts[]` 履歴化。
+- **Important I6**: ended batch 一部欠落で thread 永久消失 → §4 全 custom_id 揃いを completion 条件に。
+- **Important I7**: raw mismatch で completed 化され再取得されない → §6 で assemble 失敗＝保持/retry。
+- **Question**: early commit のローカル push → §2 CI 専用 gate。sidecar 走査位置 → §3 pre-collect で
+  `DATES_LIST` 非依存に全 sidecar を走査。

--- a/scripts/check_stuck_batches.py
+++ b/scripts/check_stuck_batches.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Print a line per sidecar whose in-flight batch is older than the stuck
+threshold. Empty output means nothing is stuck. Used by daily-batch.yml."""
+
+import glob
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pipeline import batch_state as bs  # noqa: E402
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for path in sorted(glob.glob(os.path.join(bs.PENDING_DIR, "*.json"))):
+        sc = bs.load_sidecar(path)
+        if sc and sc.get("attempts") and bs.is_stuck(sc, now):
+            print(f"- {sc['date']}: {bs.current_batch_id(sc)} "
+                  f"(age {bs.age_days(sc, now):.1f}d, retries {sc['retry_count']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pipeline/batch_state.py
+++ b/scripts/pipeline/batch_state.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 PENDING_DIR = os.path.join("data", "pending-batches")
@@ -72,3 +73,61 @@ def save_sidecar(path: str, sidecar: dict) -> None:
 def delete_sidecar(path: str) -> None:
     if os.path.exists(path):
         os.remove(path)
+
+
+HARD_FAIL_RETRIES = 3
+STUCK_AGE_DAYS = 2.0
+
+
+def add_attempt(sidecar: dict, batch_id: str, submitted_at: str) -> None:
+    sidecar["attempts"].append({
+        "batch_id": batch_id,
+        "submitted_at": submitted_at,
+        "terminal_status": None,
+        "terminal_at": None,
+    })
+
+
+def current_batch_id(sidecar: dict) -> Optional[str]:
+    if not sidecar["attempts"]:
+        return None
+    return sidecar["attempts"][-1]["batch_id"]
+
+
+def record_terminal(sidecar: dict, status: str, at: str) -> bool:
+    """Record a terminal failure on the current attempt.
+
+    Increments ``retry_count`` only on the null -> failure transition so the
+    same terminal state observed across multiple runs is not double counted.
+    Returns True if it newly transitioned (and counted), else False.
+    """
+    if not sidecar["attempts"]:
+        return False
+    attempt = sidecar["attempts"][-1]
+    if attempt["terminal_status"] is not None:
+        return False
+    attempt["terminal_status"] = status
+    attempt["terminal_at"] = at
+    sidecar["retry_count"] += 1
+    return True
+
+
+def should_hard_fail(sidecar: dict) -> bool:
+    return sidecar["retry_count"] >= HARD_FAIL_RETRIES
+
+
+def _parse_iso(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def age_days(sidecar: dict, now_iso: str) -> float:
+    submitted = sidecar["attempts"][-1]["submitted_at"]
+    delta = _parse_iso(now_iso) - _parse_iso(submitted)
+    return delta.total_seconds() / 86400.0
+
+
+def is_stuck(sidecar: dict, now_iso: str, threshold_days: float = STUCK_AGE_DAYS) -> bool:
+    return age_days(sidecar, now_iso) > threshold_days

--- a/scripts/pipeline/batch_state.py
+++ b/scripts/pipeline/batch_state.py
@@ -1,0 +1,71 @@
+"""Persistence for in-flight summary batches (cross-run resume).
+
+A sidecar at ``data/pending-batches/{date}.json`` records the batch id(s) and a
+grouping *manifest* for one date, so a timed-out batch can be collected on a
+later run without re-running the (non-deterministic-enough) grouping step.
+
+This module is pure: no Anthropic client, no network. It is the unit-testable
+core of the resume feature.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Optional
+
+PENDING_DIR = os.path.join("data", "pending-batches")
+SCHEMA_VERSION = 1
+
+# Terminal Anthropic batch statuses that are NOT a successful collection.
+TERMINAL_FAILURES = {"canceled", "expired"}
+
+
+def sidecar_path(date_str: str, pending_dir: str = PENDING_DIR) -> str:
+    return os.path.join(pending_dir, f"{date_str}.json")
+
+
+def canonical_json(obj) -> str:
+    """Deterministic JSON: sorted keys, compact separators, no ASCII escaping."""
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def compute_input_hash(params: dict) -> str:
+    """SHA256 of the canonical JSON of a batch request's ``params`` block.
+
+    Hashing the whole params (model, max_tokens, system, messages) ties a stored
+    result to the exact input + prompt that produced it, so a resume cannot
+    assemble a stale result against changed raw data or a changed prompt.
+    """
+    digest = hashlib.sha256(canonical_json(params).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def new_sidecar(date_str: str, model: str) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "date": date_str,
+        "model": model,
+        "retry_count": 0,
+        "attempts": [],
+        "meetings": [],
+    }
+
+
+def load_sidecar(path: str) -> Optional[dict]:
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_sidecar(path: str, sidecar: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(sidecar, f, ensure_ascii=False, indent=2)
+
+
+def delete_sidecar(path: str) -> None:
+    if os.path.exists(path):
+        os.remove(path)

--- a/scripts/pipeline/batch_state.py
+++ b/scripts/pipeline/batch_state.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from typing import Optional
+from typing import Any, Optional
 
 PENDING_DIR = os.path.join("data", "pending-batches")
 SCHEMA_VERSION = 1
@@ -26,7 +26,7 @@ def sidecar_path(date_str: str, pending_dir: str = PENDING_DIR) -> str:
     return os.path.join(pending_dir, f"{date_str}.json")
 
 
-def canonical_json(obj) -> str:
+def canonical_json(obj: Any) -> str:
     """Deterministic JSON: sorted keys, compact separators, no ASCII escaping."""
     return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
@@ -54,14 +54,17 @@ def new_sidecar(date_str: str, model: str) -> dict:
 
 
 def load_sidecar(path: str) -> Optional[dict]:
-    if not os.path.exists(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
         return None
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
 
 
 def save_sidecar(path: str, sidecar: dict) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    dirpart = os.path.dirname(path)
+    if dirpart:
+        os.makedirs(dirpart, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(sidecar, f, ensure_ascii=False, indent=2)
 

--- a/scripts/pipeline/summarizer.py
+++ b/scripts/pipeline/summarizer.py
@@ -189,12 +189,16 @@ def submit_summary_batch(client, requests: List[dict]) -> str:
 def poll_summary_batch(
     client,
     batch_id: str,
-    timeout_seconds: int = 5400,
+    timeout_seconds: int = 1800,
     poll_interval_seconds: int = 30,
 ):
-    """Poll a batch until it ends or the timeout elapses.
+    """Poll a batch until it ends or the budget elapses.
 
-    Returns the final batch object. Raises TimeoutError on timeout.
+    Returns the final batch object in BOTH cases. The caller inspects
+    ``batch.processing_status``: ``"ended"`` -> collect results; anything else
+    -> the batch is still in flight and will be resumed on a later run (its id
+    is persisted in a sidecar). We never cancel: cancelling would throw away a
+    batch that simply needs more time than this run's budget.
     """
     start = time.time()
     last_logged = 0.0
@@ -210,7 +214,6 @@ def poll_summary_batch(
             )
             return batch
 
-        # Log every ~2 minutes to avoid spamming CI logs
         if elapsed - last_logged >= 120:
             log.info(
                 "Batch %s status=%s elapsed=%ds",
@@ -219,21 +222,11 @@ def poll_summary_batch(
             last_logged = elapsed
 
         if elapsed >= timeout_seconds:
-            # The batch_id is not persisted across runs, so a timed-out batch
-            # can never be collected — cancel it to stop paying for results we
-            # will throw away (the next run re-submits a fresh batch anyway).
-            try:
-                client.messages.batches.cancel(batch_id)
-                log.warning("Cancelled timed-out batch %s", batch_id)
-            except Exception as cancel_err:  # noqa: BLE001 - best-effort cleanup
-                log.warning(
-                    "Failed to cancel timed-out batch %s: %s",
-                    batch_id, cancel_err,
-                )
-            raise TimeoutError(
-                f"Batch {batch_id} did not end within {timeout_seconds}s "
-                f"(last status: {batch.processing_status})"
+            log.info(
+                "Batch %s still %s after %ds budget — leaving for resume",
+                batch_id, batch.processing_status, elapsed,
             )
+            return batch
         time.sleep(poll_interval_seconds)
 
 

--- a/scripts/pytest.ini
+++ b/scripts/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+addopts = -q

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -16,9 +16,10 @@ import hashlib
 import json
 import logging
 import os
+import subprocess
 import sys
 import time
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 import anthropic
@@ -44,6 +45,25 @@ from pipeline import batch_state as bs
 log = logging.getLogger("summarize")
 
 DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_commit_sidecar(path: str, date_str: str) -> None:
+    """Commit + push just the sidecar (CI only) so the in-flight batch survives
+    a later kill or set -e failure before the run's final commit."""
+    try:
+        subprocess.run(["git", "add", path], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"chore(pipeline): persist pending batch {date_str}"],
+            check=True,
+        )
+        subprocess.run(["git", "push"], check=True)
+        log.info("Early-committed sidecar %s", path)
+    except subprocess.CalledProcessError as e:
+        log.warning("Early sidecar commit failed (%s) — relying on final commit", e)
 
 
 # ---------------------------------------------------------------------------
@@ -502,14 +522,16 @@ def run_batch_phase(
     model: str,
     date_str: str,
     thread_counter: int,
-    batch_timeout_seconds: int = 5400,  # 90 min
+    batch_timeout_seconds: int = 1800,  # 30 min default budget
     batch_poll_seconds: int = 30,
+    pending_dir: str = bs.PENDING_DIR,
+    ci_commit: bool = False,
 ) -> tuple:
-    """Process meetings via Batches API for the summary phase.
+    """Process meetings via Batches API. Persists a sidecar so a batch that
+    does not finish within the budget resumes on a later run.
 
-    Returns ``(new_threads, updated_thread_counter, completed_meeting_ids)``.
+    Returns ``(new_threads, thread_counter, completed_meeting_ids, pending)``.
     """
-    # Phase 1: synchronously group + extract outcome for every new meeting.
     prepared_meetings: list[dict] = []
     all_pending: list[dict] = []
 
@@ -518,7 +540,6 @@ def run_batch_phase(
         if meeting_id in progress["completed"]:
             log.info("Skipping already completed: %s", meeting_id)
             continue
-
         log.info("Preparing for batch: %s", meeting_id)
         try:
             prep = prepare_meeting_for_batch(client, meeting, model)
@@ -526,15 +547,13 @@ def run_batch_phase(
             log.error("Failed to prepare %s: %s", meeting_id, e)
             progress["failed"].append(meeting_id)
             continue
-
         prepared_meetings.append(prep)
         all_pending.extend(prep["pending"])
 
     if not all_pending:
         log.info("Batch phase: nothing to summarize")
-        return [], thread_counter, []
+        return [], thread_counter, [], False
 
-    # Phase 2: submit + poll + fetch.
     requests = [
         build_summary_request(
             p["meeting"], p["thread_info"], p["thread_speeches"],
@@ -544,55 +563,39 @@ def run_batch_phase(
     ]
     log.info("Submitting %d summary requests via Batches API", len(requests))
     batch_id = submit_summary_batch(client, requests)
-    poll_summary_batch(
+
+    # Persist the sidecar BEFORE the long poll so a kill mid-poll still resumes.
+    submitted_at = _utcnow_iso()
+    sidecar = bs.new_sidecar(date_str, model)
+    sidecar["meetings"] = build_manifest_meetings(prepared_meetings, model)
+    bs.add_attempt(sidecar, batch_id, submitted_at)
+    path = bs.sidecar_path(date_str, pending_dir)
+    bs.save_sidecar(path, sidecar)
+    if ci_commit:
+        _git_commit_sidecar(path, date_str)
+
+    batch = poll_summary_batch(
         client, batch_id,
         timeout_seconds=batch_timeout_seconds,
         poll_interval_seconds=batch_poll_seconds,
     )
+    if batch.processing_status != "ended":
+        log.info("Batch %s not ended within budget — sidecar kept for resume", batch_id)
+        return [], thread_counter, [], True
+
     results = fetch_summary_results(client, batch_id)
+    meetings_by_id = {m.get("meetingId", "unknown"): m for m in meetings}
+    new_threads, ok = assemble_from_manifest(
+        sidecar, meetings_by_id, results, members, thread_counter,
+    )
+    if not ok:
+        log.error("Batch %s ended but assembly incomplete — keeping sidecar", batch_id)
+        return [], thread_counter, [], True
 
-    # Phase 3: assemble threads in deterministic order (matches sync mode).
-    new_threads: list = []
-    completed_meeting_ids: list = []
-
-    for prep in prepared_meetings:
-        meeting_id = prep["meeting_id"]
-        outcome = prep["outcome"]
-        thread_infos = prep["thread_infos"]
-
-        for p in prep["pending"]:
-            result = results.get(p["custom_id"])
-            if not result:
-                log.warning(
-                    "No result for %s (thread '%s'); skipping",
-                    p["custom_id"], p["thread_info"].get("topic"),
-                )
-                continue
-
-            thread_counter += 1
-            thread_id = make_thread_id(date_str, meeting_id, thread_counter)
-            thread = assemble_thread(
-                p["meeting"], p["thread_info"], result["speeches"],
-                p["raw_lookup"], members, thread_id,
-            )
-            if not thread:
-                continue
-
-            is_last = (p["thread_info"] is thread_infos[-1])
-            thread["outcome"] = {
-                "result": outcome.get("result") if is_last else None,
-                "resolution": outcome.get("resolution") if is_last else None,
-                "commitments": result["commitments"] or [],
-                "status": outcome.get("status", "ongoing"),
-            }
-            new_threads.append(thread)
-
-        # Mark the meeting as completed even if some of its threads failed —
-        # matches the sync path, which catches per-thread exceptions inside
-        # the meeting loop and still records the meeting as done.
-        completed_meeting_ids.append(meeting_id)
-
-    return new_threads, thread_counter, completed_meeting_ids
+    thread_counter += len(new_threads)
+    completed_meeting_ids = [m["meeting_id"] for m in sidecar["meetings"]]
+    bs.delete_sidecar(path)
+    return new_threads, thread_counter, completed_meeting_ids, False
 
 
 def collect_processed_meeting_ids(threads_path: str) -> set[str]:
@@ -638,6 +641,8 @@ def run_pipeline(
     batch: bool = False,
     batch_timeout_seconds: int = 5400,
     batch_poll_seconds: int = 30,
+    pending_dir: str = bs.PENDING_DIR,
+    ci_commit: bool = False,
 ) -> None:
     """Run the full summarization pipeline for a given date."""
     # Load raw data — collect meetings from all source files for this date
@@ -730,26 +735,24 @@ def run_pipeline(
             len(all_threads),
         )
 
+    pending = False
     if batch:
-        try:
-            new_threads, thread_counter, completed_ids = run_batch_phase(
-                client, meetings, progress, members, model, date_str,
-                thread_counter,
-                batch_timeout_seconds=batch_timeout_seconds,
-                batch_poll_seconds=batch_poll_seconds,
-            )
-            all_threads.extend(new_threads)
-            for mid in completed_ids:
-                if mid not in progress["completed"]:
-                    progress["completed"].append(mid)
-            save_progress(progress, progress_path)
-            log.info("Batch phase: +%d threads from %d meeting(s)",
-                     len(new_threads), len(completed_ids))
-        except Exception as e:
-            log.error("Batch phase failed: %s", e)
-            # Don't mark any meetings completed on a batch-level failure —
-            # they'll be retried on the next run.
-            raise
+        new_threads, thread_counter, completed_ids, pending = run_batch_phase(
+            client, meetings, progress, members, model, date_str,
+            thread_counter,
+            batch_timeout_seconds=batch_timeout_seconds,
+            batch_poll_seconds=batch_poll_seconds,
+            pending_dir=pending_dir,
+            ci_commit=ci_commit,
+        )
+        all_threads.extend(new_threads)
+        for mid in completed_ids:
+            if mid not in progress["completed"]:
+                progress["completed"].append(mid)
+        save_progress(progress, progress_path)
+        log.info("Batch phase: +%d threads from %d meeting(s)%s",
+                 len(new_threads), len(completed_ids),
+                 " (batch pending — will resume)" if pending else "")
     else:
         for meeting in meetings:
             meeting_id = meeting.get("meetingId", "unknown")

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -504,6 +504,59 @@ def _append_threads_to_date_file(threads: list, threads_dir: str, date_str: str)
         json.dump(existing, f, ensure_ascii=False, indent=2)
 
 
+def _rebuild_requests_from_manifest(sidecar: dict, meetings_by_id: Dict[str, dict],
+                                    model: str) -> Optional[list]:
+    """Rebuild batch requests from a sidecar manifest for resubmission.
+
+    Reuses the persisted custom_ids and thread_info (NO re-grouping), so a
+    resubmitted batch's results still match the manifest's input_hash. Returns
+    None if raw is missing or a speechOrder gap prevents a faithful rebuild.
+    """
+    requests: list = []
+    for m in sidecar["meetings"]:
+        meeting = meetings_by_id.get(m["meeting_id"])
+        if meeting is None:
+            return None
+        raw_lookup = build_speech_lookup(meeting.get("speeches", []))
+        for mt in m["threads"]:
+            orders = mt["speechOrders"]
+            thread_speeches = [raw_lookup[o] for o in orders if o in raw_lookup]
+            if len(thread_speeches) != len(orders):
+                return None
+            requests.append(build_summary_request(
+                meeting, mt["thread_info"], thread_speeches, mt["custom_id"], model,
+            ))
+    return requests
+
+
+def _retry_or_hardfail(client, sidecar: dict, path: str, reason: str,
+                       raw_dir: str, model: str, ci_commit: bool) -> bool:
+    """Count a non-collectable batch failure, then either hard-fail (>=3 retries)
+    or resubmit a fresh batch from the manifest (new attempt). Returns True on
+    hard-fail (caller should exit non-zero)."""
+    bs.record_terminal(sidecar, reason, _utcnow_iso())
+    if bs.should_hard_fail(sidecar):
+        bs.save_sidecar(path, sidecar)
+        log.error("Sidecar %s hit retry threshold (%d, last=%s) — hard fail",
+                  path, sidecar["retry_count"], reason)
+        return True
+    meetings_by_id = _load_meetings_for_date(sidecar["date"], raw_dir)
+    requests = _rebuild_requests_from_manifest(sidecar, meetings_by_id, model)
+    if requests is None:
+        bs.save_sidecar(path, sidecar)
+        log.error("Resume: cannot rebuild %s for resubmit (raw missing/gap) — keeping sidecar",
+                  sidecar["date"])
+        return False
+    new_batch_id = submit_summary_batch(client, requests)
+    bs.add_attempt(sidecar, new_batch_id, _utcnow_iso())
+    bs.save_sidecar(path, sidecar)
+    if ci_commit:
+        _git_commit_sidecar(path, sidecar["date"])
+    log.warning("Resubmitted %s as %s after %s (retry %d)",
+                sidecar["date"], new_batch_id, reason, sidecar["retry_count"])
+    return False
+
+
 def collect_pending_batches(
     client,
     members: Dict[str, dict],
@@ -540,12 +593,9 @@ def collect_pending_batches(
 
         if batch.processing_status != "ended":
             if batch.processing_status in bs.TERMINAL_FAILURES:
-                if bs.record_terminal(sidecar, batch.processing_status, _utcnow_iso()):
-                    bs.save_sidecar(path, sidecar)
-                    if ci_commit:
-                        _git_commit_sidecar(path, date_str)
-                log.warning("Batch %s %s — will re-submit next run", batch_id,
-                            batch.processing_status)
+                if _retry_or_hardfail(client, sidecar, path, batch.processing_status,
+                                      raw_dir, model, ci_commit):
+                    hard_fail = True
             else:
                 log.info("Batch %s still %s — leaving for next run", batch_id,
                          batch.processing_status)
@@ -561,9 +611,10 @@ def collect_pending_batches(
             sidecar, meetings_by_id, results, members, thread_counter=0,
         )
         if not ok:
-            if bs.record_terminal(sidecar, "assemble_failed", _utcnow_iso()):
-                bs.save_sidecar(path, sidecar)
-            log.error("Resume: assembly incomplete for %s — keeping sidecar", date_str)
+            log.error("Resume: assembly incomplete for %s", date_str)
+            if _retry_or_hardfail(client, sidecar, path, "assemble_failed",
+                                  raw_dir, model, ci_commit):
+                hard_fail = True
             continue
 
         _append_threads_to_date_file(threads, threads_dir, date_str)

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -377,6 +377,78 @@ def build_manifest_meetings(prepared_meetings: list, model: str) -> list:
     return meetings
 
 
+def assemble_from_manifest(
+    sidecar: dict,
+    meetings_by_id: Dict[str, dict],
+    results: Dict[str, Optional[dict]],
+    members: Dict[str, dict],
+    thread_counter: int,
+) -> tuple:
+    """Assemble threads from a sidecar manifest + a completed batch's results.
+
+    Does NOT re-group. Verifies each thread's input_hash against re-fetched raw
+    and requires every custom_id to have a parsed result. Returns
+    ``(threads, ok)`` where ok is False if ANY thread fails verification or is
+    missing — in that case the caller keeps the sidecar for retry.
+    """
+    model = sidecar["model"]
+    date_str = sidecar["date"]
+    threads: list = []
+
+    for m in sidecar["meetings"]:
+        meeting_id = m["meeting_id"]
+        meeting = meetings_by_id.get(meeting_id)
+        if meeting is None:
+            log.error("Resume: raw missing for %s — cannot assemble", meeting_id)
+            return [], False
+        raw_lookup = build_speech_lookup(meeting.get("speeches", []))
+        outcome = m["outcome"]
+        manifest_threads = m["threads"]
+
+        for mt in manifest_threads:
+            custom_id = mt["custom_id"]
+            thread_info = mt["thread_info"]
+            orders = mt["speechOrders"]
+            thread_speeches = [raw_lookup[o] for o in orders if o in raw_lookup]
+            if len(thread_speeches) != len(orders):
+                log.error("Resume: speechOrder gap in %s/%s", meeting_id, custom_id)
+                return [], False
+
+            request = build_summary_request(
+                meeting, thread_info, thread_speeches, custom_id, model,
+            )
+            if bs.compute_input_hash(request["params"]) != mt["input_hash"]:
+                log.error("Resume: input_hash mismatch for %s — raw/prompt changed",
+                          custom_id)
+                return [], False
+
+            result = results.get(custom_id)
+            if not result:
+                log.error("Resume: missing result for %s", custom_id)
+                return [], False
+
+            thread_counter += 1
+            thread_id = make_thread_id(date_str, meeting_id, thread_counter)
+            thread = assemble_thread(
+                meeting, thread_info, result["speeches"], raw_lookup, members,
+                thread_id,
+            )
+            if not thread:
+                log.error("Resume: assemble_thread returned None for %s", custom_id)
+                return [], False
+
+            is_last = (mt is manifest_threads[-1])
+            thread["outcome"] = {
+                "result": outcome.get("result") if is_last else None,
+                "resolution": outcome.get("resolution") if is_last else None,
+                "commitments": result["commitments"] or [],
+                "status": outcome.get("status", "ongoing"),
+            }
+            threads.append(thread)
+
+    return threads, True
+
+
 def prepare_meeting_for_batch(
     client,
     meeting: dict,

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -469,6 +469,110 @@ def assemble_from_manifest(
     return threads, True
 
 
+def _load_meetings_for_date(date_str: str, raw_dir: str) -> Dict[str, dict]:
+    """Re-load all meetings for a date from raw files, keyed by meetingId.
+
+    Mirrors run_pipeline's candidate-file scan so resume sees the same raw.
+    """
+    import glob as _glob
+    candidates = [
+        os.path.join(raw_dir, f"ndl-{date_str}.json"),
+        os.path.join(raw_dir, f"kantei-{date_str}.json"),
+        os.path.join(raw_dir, f"council-{date_str}.json"),
+        *sorted(_glob.glob(os.path.join(raw_dir, f"council-*-{date_str}.json"))),
+        os.path.join(raw_dir, f"{date_str}.json"),
+    ]
+    by_id: Dict[str, dict] = {}
+    for c in candidates:
+        if os.path.exists(c):
+            with open(c, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for m in data.get("meetings", []):
+                by_id[m.get("meetingId", "unknown")] = m
+    return by_id
+
+
+def _append_threads_to_date_file(threads: list, threads_dir: str, date_str: str) -> None:
+    os.makedirs(threads_dir, exist_ok=True)
+    path = os.path.join(threads_dir, f"{date_str}.json")
+    existing = []
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    existing.extend(threads)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, ensure_ascii=False, indent=2)
+
+
+def collect_pending_batches(
+    client,
+    members: Dict[str, dict],
+    model: str,
+    pending_dir: str = bs.PENDING_DIR,
+    threads_dir: str = "data/threads",
+    raw_dir: str = "data/raw",
+    budget_seconds: int = 1800,
+    poll_seconds: int = 30,
+    ci_commit: bool = False,
+) -> bool:
+    """Resume all in-flight batches. Returns True if any sidecar hit the
+    hard-fail retry threshold (caller should exit non-zero)."""
+    import glob as _glob
+    hard_fail = False
+    paths = sorted(_glob.glob(os.path.join(pending_dir, "*.json")))
+    deadline = time.time() + budget_seconds
+
+    for path in paths:
+        sidecar = bs.load_sidecar(path)
+        if sidecar is None:
+            continue
+        if bs.should_hard_fail(sidecar):
+            log.error("Sidecar %s exceeded retry threshold (%d) — hard fail",
+                      path, sidecar["retry_count"])
+            hard_fail = True
+            continue
+
+        date_str = sidecar["date"]
+        batch_id = bs.current_batch_id(sidecar)
+        remaining = max(0, int(deadline - time.time()))
+        batch = poll_summary_batch(client, batch_id,
+                                   timeout_seconds=remaining, poll_interval_seconds=poll_seconds)
+
+        if batch.processing_status != "ended":
+            if batch.processing_status in bs.TERMINAL_FAILURES:
+                if bs.record_terminal(sidecar, batch.processing_status, _utcnow_iso()):
+                    bs.save_sidecar(path, sidecar)
+                    if ci_commit:
+                        _git_commit_sidecar(path, date_str)
+                log.warning("Batch %s %s — will re-submit next run", batch_id,
+                            batch.processing_status)
+            else:
+                log.info("Batch %s still %s — leaving for next run", batch_id,
+                         batch.processing_status)
+            continue
+
+        results = fetch_summary_results(client, batch_id)
+        meetings_by_id = _load_meetings_for_date(date_str, raw_dir)
+        if not meetings_by_id:
+            log.error("Resume: no raw for %s (outside window?) — keeping sidecar",
+                      date_str)
+            continue
+        threads, ok = assemble_from_manifest(
+            sidecar, meetings_by_id, results, members, thread_counter=0,
+        )
+        if not ok:
+            if bs.record_terminal(sidecar, "assemble_failed", _utcnow_iso()):
+                bs.save_sidecar(path, sidecar)
+            log.error("Resume: assembly incomplete for %s — keeping sidecar", date_str)
+            continue
+
+        _append_threads_to_date_file(threads, threads_dir, date_str)
+        bs.delete_sidecar(path)
+        log.info("Resume: collected %d threads for %s", len(threads), date_str)
+
+    return hard_fail
+
+
 def prepare_meeting_for_batch(
     client,
     meeting: dict,

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -39,6 +39,7 @@ from pipeline.summarizer import (
 )
 from pipeline.members import extract_member, load_members, save_members
 from pipeline.linker import link_threads
+from pipeline import batch_state as bs
 
 log = logging.getLogger("summarize")
 
@@ -344,6 +345,36 @@ def make_batch_custom_id(meeting_id: str, thread_idx: int) -> str:
     """
     h = hashlib.sha256(meeting_id.encode("utf-8")).hexdigest()[:12]
     return f"s_{h}_{thread_idx:02d}"
+
+
+def build_manifest_meetings(prepared_meetings: list, model: str) -> list:
+    """Build sidecar ``meetings[]`` from prepared meetings.
+
+    Captures the FULL thread_info (assemble_thread needs topicTag/topicColor/
+    summary/etc.) plus a per-thread input_hash so a resumed batch result can be
+    verified against re-fetched raw before being assembled.
+    """
+    meetings = []
+    for prep in prepared_meetings:
+        threads = []
+        for idx, p in enumerate(prep["pending"]):
+            request = build_summary_request(
+                p["meeting"], p["thread_info"], p["thread_speeches"],
+                p["custom_id"], model,
+            )
+            threads.append({
+                "custom_id": p["custom_id"],
+                "thread_idx": idx,
+                "thread_info": p["thread_info"],
+                "speechOrders": p["thread_info"].get("speechOrders", []),
+                "input_hash": bs.compute_input_hash(request["params"]),
+            })
+        meetings.append({
+            "meeting_id": prep["meeting_id"],
+            "outcome": prep["outcome"],
+            "threads": threads,
+        })
+    return meetings
 
 
 def prepare_meeting_for_batch(

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -961,12 +961,29 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
              "stackable with prompt caching). Polls until results are ready.",
     )
     parser.add_argument(
-        "--batch-timeout", type=int, default=5400,
-        help="Max seconds to wait for batch completion (default: 5400 = 90min)",
+        "--batch-timeout", type=int, default=1800,
+        help="Max seconds to wait for batch completion (default: 1800 = 30min)",
     )
     parser.add_argument(
         "--batch-poll", type=int, default=30,
         help="Seconds between batch status polls (default: 30)",
+    )
+    parser.add_argument(
+        "--collect-pending", action="store_true",
+        help="Resume in-flight batches from data/pending-batches/ and exit. "
+             "Non-zero exit if a sidecar exceeds the retry threshold.",
+    )
+    parser.add_argument(
+        "--pending-dir", default="data/pending-batches",
+        help="Directory for in-flight batch sidecars",
+    )
+    parser.add_argument(
+        "--batch-budget", type=int, default=1800,
+        help="Per-run poll budget in seconds (default 1800 = 30min)",
+    )
+    parser.add_argument(
+        "--ci-commit", action="store_true",
+        help="Early-commit+push the sidecar after submit (CI only)",
     )
 
     return parser.parse_args(argv)
@@ -980,6 +997,20 @@ def main(argv: Optional[List[str]] = None) -> None:
         format="%(levelname)s %(message)s",
     )
 
+    if args.collect_pending:
+        client = anthropic.Anthropic()
+        members = load_members(args.members_path)
+        hard_fail = collect_pending_batches(
+            client, members, args.model,
+            pending_dir=args.pending_dir, threads_dir=args.output_dir,
+            raw_dir=args.raw_dir, budget_seconds=args.batch_budget,
+            poll_seconds=args.batch_poll, ci_commit=args.ci_commit,
+        )
+        save_members(members, args.members_path)
+        if hard_fail:
+            sys.exit(1)
+        return
+
     run_pipeline(
         date_str=args.date,
         meeting_filter=args.meeting,
@@ -991,8 +1022,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         dry_run=args.dry_run,
         verbose=args.verbose,
         batch=args.batch,
-        batch_timeout_seconds=args.batch_timeout,
+        batch_timeout_seconds=args.batch_budget,
         batch_poll_seconds=args.batch_poll,
+        pending_dir=args.pending_dir,
+        ci_commit=args.ci_commit,
     )
 
 

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Shared pytest fixtures: a fake Anthropic Batches client.
+
+The fake mimics only the surface summarize.py uses:
+  client.messages.batches.create(requests=...)  -> object with .id / .processing_status
+  client.messages.batches.retrieve(batch_id)    -> object with .processing_status / .request_counts
+  client.messages.batches.results(batch_id)     -> iterable of result entries
+It is driven entirely by attributes set in each test (no network).
+"""
+
+import sys
+import os
+import types
+
+import pytest
+
+# Make `pipeline` importable exactly as summarize.py does.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class _Batch:
+    def __init__(self, batch_id, status, counts=None):
+        self.id = batch_id
+        self.processing_status = status
+        self.request_counts = counts or {}
+
+
+class _ResultEntry:
+    def __init__(self, custom_id, result_type, text=None):
+        self.custom_id = custom_id
+        message = types.SimpleNamespace(
+            content=[types.SimpleNamespace(text=text)] if text is not None else [],
+            usage=None,
+        )
+        self.result = types.SimpleNamespace(type=result_type, message=message)
+
+
+class FakeBatches:
+    def __init__(self):
+        # Tests set these to script behavior.
+        self.created_requests = []
+        self.next_id = "msgbatch_fake_0001"
+        self.statuses = {}          # batch_id -> processing_status to return
+        self.results_by_id = {}     # batch_id -> list[_ResultEntry]
+        self.cancelled = []
+
+    def create(self, requests):
+        self.created_requests.append(requests)
+        bid = self.next_id
+        self.statuses.setdefault(bid, "in_progress")
+        return _Batch(bid, self.statuses[bid])
+
+    def retrieve(self, batch_id):
+        return _Batch(batch_id, self.statuses.get(batch_id, "in_progress"),
+                      counts={"succeeded": len(self.results_by_id.get(batch_id, []))})
+
+    def results(self, batch_id):
+        return list(self.results_by_id.get(batch_id, []))
+
+    def cancel(self, batch_id):
+        self.cancelled.append(batch_id)
+
+
+class FakeClient:
+    def __init__(self):
+        self.messages = types.SimpleNamespace(batches=FakeBatches())
+
+
+@pytest.fixture
+def fake_client():
+    return FakeClient()

--- a/scripts/tests/test_batch_state.py
+++ b/scripts/tests/test_batch_state.py
@@ -51,3 +51,50 @@ def test_sidecar_path_lives_outside_threads():
     p = bs.sidecar_path("2026-05-14")
     assert p == os.path.join("data", "pending-batches", "2026-05-14.json")
     assert "threads" not in p
+
+
+def test_add_attempt_and_current_batch_id():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    assert bs.current_batch_id(sc) == "msgbatch_A"
+    assert sc["attempts"][-1]["terminal_status"] is None
+
+
+def test_record_terminal_increments_once_per_transition():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    # First observation of a failure transitions null -> expired: count.
+    assert bs.record_terminal(sc, "expired", "2026-06-11T23:20:00Z") is True
+    assert sc["retry_count"] == 1
+    # Re-observing the same terminal on the same attempt must NOT double count.
+    assert bs.record_terminal(sc, "expired", "2026-06-12T00:00:00Z") is False
+    assert sc["retry_count"] == 1
+
+
+def test_record_terminal_three_failures_across_attempts():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    for i in range(3):
+        bs.add_attempt(sc, f"msgbatch_{i}", "2026-06-11T21:50:00Z")
+        assert bs.record_terminal(sc, "expired", "2026-06-11T23:20:00Z") is True
+    assert sc["retry_count"] == 3
+    assert bs.should_hard_fail(sc) is True
+
+
+def test_should_hard_fail_below_threshold():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-11T21:50:00Z")
+    bs.record_terminal(sc, "canceled", "2026-06-11T23:20:00Z")
+    assert bs.should_hard_fail(sc) is False
+
+
+def test_age_days_from_last_attempt():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-10T00:00:00Z")
+    assert bs.age_days(sc, "2026-06-12T00:00:00Z") == 2.0
+
+
+def test_is_stuck_uses_threshold():
+    sc = bs.new_sidecar("2026-05-14", "m")
+    bs.add_attempt(sc, "msgbatch_A", "2026-06-10T00:00:00Z")
+    assert bs.is_stuck(sc, "2026-06-12T01:00:00Z") is True   # >2d
+    assert bs.is_stuck(sc, "2026-06-11T00:00:00Z") is False  # 1d

--- a/scripts/tests/test_batch_state.py
+++ b/scripts/tests/test_batch_state.py
@@ -1,0 +1,53 @@
+import json
+import os
+
+from pipeline import batch_state as bs
+
+
+def test_canonical_json_is_order_insensitive():
+    a = bs.canonical_json({"b": 1, "a": [3, 2]})
+    b = bs.canonical_json({"a": [3, 2], "b": 1})
+    assert a == b
+
+
+def test_compute_input_hash_stable_and_prefixed():
+    params = {"model": "m", "max_tokens": 8192, "system": "S",
+              "messages": [{"role": "user", "content": "x"}]}
+    h1 = bs.compute_input_hash(params)
+    h2 = bs.compute_input_hash(dict(reversed(list(params.items()))))
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_compute_input_hash_changes_with_prompt():
+    p1 = {"system": "A", "messages": []}
+    p2 = {"system": "B", "messages": []}
+    assert bs.compute_input_hash(p1) != bs.compute_input_hash(p2)
+
+
+def test_new_sidecar_shape():
+    sc = bs.new_sidecar("2026-05-14", "claude-x")
+    assert sc["schema_version"] == 1
+    assert sc["date"] == "2026-05-14"
+    assert sc["model"] == "claude-x"
+    assert sc["retry_count"] == 0
+    assert sc["attempts"] == []
+    assert sc["meetings"] == []
+
+
+def test_save_load_delete_roundtrip(tmp_path):
+    path = str(tmp_path / "2026-05-14.json")
+    sc = bs.new_sidecar("2026-05-14", "claude-x")
+    bs.save_sidecar(path, sc)
+    assert os.path.exists(path)
+    loaded = bs.load_sidecar(path)
+    assert loaded == sc
+    bs.delete_sidecar(path)
+    assert not os.path.exists(path)
+    assert bs.load_sidecar(path) is None
+
+
+def test_sidecar_path_lives_outside_threads():
+    p = bs.sidecar_path("2026-05-14")
+    assert p == os.path.join("data", "pending-batches", "2026-05-14.json")
+    assert "threads" not in p

--- a/scripts/tests/test_poll.py
+++ b/scripts/tests/test_poll.py
@@ -1,0 +1,19 @@
+from pipeline.summarizer import poll_summary_batch
+
+
+def test_poll_returns_ended_batch(fake_client):
+    b = fake_client.messages.batches
+    b.statuses["msgbatch_X"] = "ended"
+    batch = poll_summary_batch(fake_client, "msgbatch_X",
+                               timeout_seconds=5, poll_interval_seconds=0)
+    assert batch.processing_status == "ended"
+    assert b.cancelled == []  # never cancels
+
+
+def test_poll_returns_pending_on_budget_exhaustion(fake_client):
+    b = fake_client.messages.batches
+    b.statuses["msgbatch_Y"] = "in_progress"
+    batch = poll_summary_batch(fake_client, "msgbatch_Y",
+                               timeout_seconds=0, poll_interval_seconds=0)
+    assert batch.processing_status == "in_progress"
+    assert b.cancelled == []  # no cancel — the batch is resumed next run

--- a/scripts/tests/test_resume.py
+++ b/scripts/tests/test_resume.py
@@ -1,0 +1,39 @@
+from pipeline import batch_state as bs
+import summarize
+
+
+def _prep(meeting_id, threads):
+    """Mimic prepare_meeting_for_batch's output shape."""
+    return {
+        "meeting_id": meeting_id,
+        "outcome": {"result": None, "resolution": None, "status": "ongoing"},
+        "pending": [
+            {
+                "custom_id": t["custom_id"],
+                "meeting": {"house": "参議院", "meeting": "外交防衛委員会"},
+                "thread_info": t["thread_info"],
+                "thread_speeches": t["speeches"],
+            }
+            for t in threads
+        ],
+    }
+
+
+def test_build_manifest_meetings_captures_full_thread_info_and_hash():
+    threads = [{
+        "custom_id": "s_abc_00",
+        "thread_info": {"topic": "T", "topicTag": "tag", "topicColor": "#111",
+                        "summary": "s", "speechOrders": [1, 2]},
+        "speeches": [{"speechOrder": 1, "speech": "a"}, {"speechOrder": 2, "speech": "b"}],
+    }]
+    prepared = [_prep("M1", threads)]
+    manifest = summarize.build_manifest_meetings(prepared, model="claude-x")
+    assert len(manifest) == 1
+    m = manifest[0]
+    assert m["meeting_id"] == "M1"
+    t = m["threads"][0]
+    assert t["custom_id"] == "s_abc_00"
+    assert t["thread_idx"] == 0
+    assert t["thread_info"]["topicTag"] == "tag"   # FULL thread_info, not a subset
+    assert t["speechOrders"] == [1, 2]
+    assert t["input_hash"].startswith("sha256:")

--- a/scripts/tests/test_resume.py
+++ b/scripts/tests/test_resume.py
@@ -102,3 +102,33 @@ def test_assemble_fails_on_missing_result():
         sidecar, {"M1": _meeting()}, results={}, members={}, thread_counter=0,
     )
     assert ok is False
+
+
+import os
+
+
+def test_run_batch_phase_persists_sidecar_when_pending(fake_client, tmp_path, monkeypatch):
+    # One meeting, grouping stubbed to a single thread; batch stays in_progress.
+    monkeypatch.setattr(summarize, "group_meeting",
+                        lambda c, m, model: [{"topic": "T", "topicTag": "tag",
+                                              "topicColor": "#111", "summary": "s",
+                                              "speechOrders": [1]}])
+    monkeypatch.setattr(summarize, "extract_meeting_outcome",
+                        lambda c, m, model: {"result": None, "resolution": None,
+                                             "status": "ongoing"})
+    pending_dir = str(tmp_path / "pending")
+    meeting = _meeting()
+    fake_client.messages.batches.statuses["msgbatch_fake_0001"] = "in_progress"
+
+    new_threads, _, completed, pending = summarize.run_batch_phase(
+        fake_client, [meeting], {"completed": [], "failed": []},
+        members={}, model="claude-x", date_str="2026-05-14", thread_counter=0,
+        batch_timeout_seconds=0, batch_poll_seconds=0,
+        pending_dir=pending_dir, ci_commit=False,
+    )
+    assert pending is True
+    assert new_threads == []
+    sc = bs.load_sidecar(os.path.join(pending_dir, "2026-05-14.json"))
+    assert sc is not None
+    assert bs.current_batch_id(sc) == "msgbatch_fake_0001"
+    assert sc["meetings"][0]["threads"][0]["input_hash"].startswith("sha256:")

--- a/scripts/tests/test_resume.py
+++ b/scripts/tests/test_resume.py
@@ -176,3 +176,30 @@ def test_collect_hard_fails_at_retry_threshold(fake_client, tmp_path):
         budget_seconds=0, poll_seconds=0, ci_commit=False,
     )
     assert hard_fail is True
+
+
+def test_collect_resubmits_on_expired(fake_client, tmp_path):
+    pending_dir = str(tmp_path / "pending")
+    raw_dir = str(tmp_path / "raw")
+    os.makedirs(raw_dir)
+    import json as _json
+    with open(os.path.join(raw_dir, "ndl-2026-05-14.json"), "w", encoding="utf-8") as f:
+        _json.dump({"meetings": [_meeting()]}, f, ensure_ascii=False)
+    sidecar = _sidecar_with_one_thread(_correct_hash())  # current batch id "b1"
+    bs.save_sidecar(os.path.join(pending_dir, "2026-05-14.json"), sidecar)
+    b = fake_client.messages.batches
+    b.statuses["b1"] = "expired"
+    b.next_id = "msgbatch_resub_1"
+    b.statuses["msgbatch_resub_1"] = "in_progress"
+
+    hard = summarize.collect_pending_batches(
+        fake_client, members={}, model="claude-x",
+        pending_dir=pending_dir, threads_dir=str(tmp_path / "t"), raw_dir=raw_dir,
+        budget_seconds=0, poll_seconds=0, ci_commit=False,
+    )
+    assert hard is False
+    sc = bs.load_sidecar(os.path.join(pending_dir, "2026-05-14.json"))
+    assert sc is not None                       # kept — resubmitted, not abandoned
+    assert sc["retry_count"] == 1               # the expired batch counted once
+    assert bs.current_batch_id(sc) == "msgbatch_resub_1"  # a new attempt was pushed
+    assert len(sc["attempts"]) == 2

--- a/scripts/tests/test_resume.py
+++ b/scripts/tests/test_resume.py
@@ -132,3 +132,47 @@ def test_run_batch_phase_persists_sidecar_when_pending(fake_client, tmp_path, mo
     assert sc is not None
     assert bs.current_batch_id(sc) == "msgbatch_fake_0001"
     assert sc["meetings"][0]["threads"][0]["input_hash"].startswith("sha256:")
+
+
+def test_collect_assembles_ended_and_deletes_sidecar(fake_client, tmp_path, monkeypatch):
+    pending_dir = str(tmp_path / "pending")
+    threads_dir = str(tmp_path / "threads")
+    raw_dir = str(tmp_path / "raw")
+    os.makedirs(raw_dir)
+    # Write raw for the date so collect can re-fetch from disk.
+    import json as _json
+    with open(os.path.join(raw_dir, "ndl-2026-05-14.json"), "w", encoding="utf-8") as f:
+        _json.dump({"meetings": [_meeting()]}, f, ensure_ascii=False)
+    # Sidecar with a correct hash, batch now ended with a result.
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    bs.save_sidecar(os.path.join(pending_dir, "2026-05-14.json"), sidecar)
+    b = fake_client.messages.batches
+    b.statuses["b1"] = "ended"
+    from tests.conftest import _ResultEntry  # type: ignore
+    import json as J
+    b.results_by_id["b1"] = [_ResultEntry("s_abc_00", "succeeded",
+        text=J.dumps({"speeches": [{"speechOrder": 1, "tension": "確認",
+        "summaries": {"easy": "e", "teen": "t", "adult": "a"}}], "commitments": []}))]
+
+    hard_fail = summarize.collect_pending_batches(
+        fake_client, members={}, model="claude-x",
+        pending_dir=pending_dir, threads_dir=threads_dir, raw_dir=raw_dir,
+        budget_seconds=0, poll_seconds=0, ci_commit=False,
+    )
+    assert hard_fail is False
+    assert not os.path.exists(os.path.join(pending_dir, "2026-05-14.json"))
+    assert os.path.exists(os.path.join(threads_dir, "2026-05-14.json"))
+
+
+def test_collect_hard_fails_at_retry_threshold(fake_client, tmp_path):
+    pending_dir = str(tmp_path / "pending")
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    sidecar["retry_count"] = 3
+    bs.save_sidecar(os.path.join(pending_dir, "2026-05-14.json"), sidecar)
+    hard_fail = summarize.collect_pending_batches(
+        fake_client, members={}, model="claude-x",
+        pending_dir=pending_dir, threads_dir=str(tmp_path / "t"),
+        raw_dir=str(tmp_path / "r"),
+        budget_seconds=0, poll_seconds=0, ci_commit=False,
+    )
+    assert hard_fail is True

--- a/scripts/tests/test_resume.py
+++ b/scripts/tests/test_resume.py
@@ -37,3 +37,68 @@ def test_build_manifest_meetings_captures_full_thread_info_and_hash():
     assert t["thread_info"]["topicTag"] == "tag"   # FULL thread_info, not a subset
     assert t["speechOrders"] == [1, 2]
     assert t["input_hash"].startswith("sha256:")
+
+
+def _sidecar_with_one_thread(input_hash):
+    return {
+        "schema_version": 1, "date": "2026-05-14", "model": "claude-x",
+        "retry_count": 0,
+        "attempts": [{"batch_id": "b1", "submitted_at": "2026-06-11T21:50:00Z",
+                      "terminal_status": None, "terminal_at": None}],
+        "meetings": [{
+            "meeting_id": "M1",
+            "outcome": {"result": None, "resolution": None, "status": "ongoing"},
+            "threads": [{
+                "custom_id": "s_abc_00", "thread_idx": 0,
+                "thread_info": {"topic": "T", "topicTag": "tag", "topicColor": "#111",
+                                "summary": "s", "speechOrders": [1]},
+                "speechOrders": [1], "input_hash": input_hash,
+            }],
+        }],
+    }
+
+
+def _meeting():
+    return {"meetingId": "M1", "house": "参議院", "meeting": "外交防衛委員会",
+            "date": "2026-05-14", "source": "ndl",
+            "speeches": [{"speechOrder": 1, "speech": "a", "speaker": "X",
+                          "speakerGroup": "G", "speakerPosition": "P",
+                          "speechURL": "http://x"}]}
+
+
+def _correct_hash():
+    m = _meeting()
+    ti = {"topic": "T", "topicTag": "tag", "topicColor": "#111", "summary": "s",
+          "speechOrders": [1]}
+    req = summarize.build_summary_request(m, ti, [m["speeches"][0]], "s_abc_00", "claude-x")
+    return bs.compute_input_hash(req["params"])
+
+
+def test_assemble_from_manifest_success():
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    results = {"s_abc_00": {"speeches": [{"speechOrder": 1, "tension": "確認",
+               "summaries": {"easy": "e", "teen": "t", "adult": "a"}}],
+               "commitments": []}}
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results, members={}, thread_counter=0,
+    )
+    assert ok is True
+    assert len(threads) == 1
+    assert threads[0]["topicTag"] == "tag"
+
+
+def test_assemble_fails_on_hash_mismatch():
+    sidecar = _sidecar_with_one_thread("sha256:deadbeef")  # wrong
+    results = {"s_abc_00": {"speeches": [{"speechOrder": 1}], "commitments": []}}
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results, members={}, thread_counter=0,
+    )
+    assert ok is False
+
+
+def test_assemble_fails_on_missing_result():
+    sidecar = _sidecar_with_one_thread(_correct_hash())
+    threads, ok = summarize.assemble_from_manifest(
+        sidecar, {"M1": _meeting()}, results={}, members={}, thread_counter=0,
+    )
+    assert ok is False


### PR DESCRIPTION
## Summary

The daily-batch pipeline failed two days running (6/10–6/11, ~1h34m each) because Anthropic summary batches stayed `in_progress` past the 90-min poll. The previous fix (`58c0ed9`) cancelled the timed-out batch — which created a **structural deadlock**: while Anthropic is congested, every run submits → waits → cancels → fails → re-submits the same meetings, so data never advances.

This PR makes batches **resumable across runs** (the root fix flagged in `project_daily_batch_failures`):

- **Persist instead of cancel.** On submit, `batch_id` + a grouping *manifest* (full `thread_info` + per-thread `input_hash`) are written to a committed sidecar `data/pending-batches/{date}.json` (outside `data/threads/` so the SSG consumers that spread `*.json` as arrays aren't broken). `poll_summary_batch` no longer cancels/raises — it returns the batch status.
- **Resume without re-grouping.** A pre-collect pass (`summarize.py --collect-pending`) retrieves each in-flight batch; on `ended` it re-fetches raw, verifies `input_hash`, and assembles from the manifest. Re-grouping is avoided on purpose — `custom_id` is positional (`s_{sha256(meeting_id)[:12]}_{idx}`), so re-grouping could silently attach a stale summary to a different thread.
- **Bounded retries.** Terminal failures (expired/canceled/assembly-failure) resubmit a fresh batch from the manifest and advance `retry_count`; after 3 strikes the run hard-fails (CI red). A batch stuck in-flight >2 days alerts via a dedicated `notify-stuck-batch` job (`issues: write`, separate from the `contents: write`-only main job).
- **No piling up.** A `concurrency` lock + pre-collect `HAS_PENDING` gate + break-on-pending keep at most one in-flight batch per date and the per-run poll budget bounded well under the 120-min job timeout.

Design + plan: `docs/superpowers/specs/2026-06-12-batch-resume-design.md`, `docs/superpowers/plans/2026-06-12-batch-resume.md` (3 rounds of external review reflected).

## Test Plan

- [x] New pytest suite (`scripts/tests/`, 22 tests) — sidecar lifecycle, hash round-trip, retry state machine, poll-returns-status, manifest assemble (fail-closed on hash mismatch / missing result), collect resume + resubmit + hard-fail. Wired into `ci.yml`.
- [x] Both workflow YAMLs validated (`yaml.safe_load`).
- [ ] First scheduled run: confirm a timed-out batch leaves a committed sidecar and the next run collects it (watch Issue #41 / the `Daily Batch` run).

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)